### PR TITLE
fix: tsconfig.app.jsonのtsBuildInfoFileエラーを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
+      "tsc --noEmit",
       "eslint --fix",
       "prettier --write"
     ],

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "incremental": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",
     "useDefineForClassFields": true,


### PR DESCRIPTION
## 概要
tsconfig.app.jsonで発生していたTypeScriptエラーを修正しました。

## エラー内容
```
オプション 'tsBuildInfoFile' は、オプション 'incremental' または 'composite' を指定せずに、または 'tsc -b' を実行していない場合は指定できません。
```

## 修正内容
- `incremental: true` をcompilerOptionsに追加
- これにより`tsBuildInfoFile`オプションが正常に動作するようになりました

## テスト結果
- ✅ ESLintエラーなし
- ✅ TypeScriptコンパイルエラーなし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **チョア**
  * ビルドの高速化のため、TypeScriptのインクリメンタルコンパイル設定を有効化しました。
  * 型チェックの強化のため、コミット前のTypeScriptコンパイル検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->