### PR TITLE
fix: ビルドエラーとTypeScriptエラーを修正

### DIFF
--- a/src/components/NurseryCard.test.tsx
+++ b/src/components/NurseryCard.test.tsx
@@ -8,7 +8,7 @@ import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { renderWithProviders, testUtils } from '../test/test-utils';
 import { NurseryCard } from './NurseryCard';
-// Nursery型は testUtils.createMockNursery で使用
+import type { Nursery } from '../types/data';
 
 describe('NurseryCard コンポーネント', () => {
   describe('基本表示', () => {
@@ -152,7 +152,7 @@ describe('NurseryCard コンポーネント', () => {
 
       // TypeScriptエラーを回避するためのキャスト
       const onClickUndefined = undefined as unknown as (
-        nursery: typeof nursery
+        nursery: Nursery
       ) => void;
 
       expect(() => {

--- a/src/components/QuestionItem.tsx
+++ b/src/components/QuestionItem.tsx
@@ -9,7 +9,7 @@ import {
   Input,
   Textarea,
 } from '@chakra-ui/react';
-import type { Question } from '../types';
+import type { Question, QuestionPriority } from '../types/data';
 
 interface QuestionItemProps {
   question: Question;
@@ -131,7 +131,7 @@ export const QuestionItem = ({
                 />
                 <select
                   value={editedPriority}
-                  onChange={(e) => setEditedPriority(e.target.value)}
+                  onChange={(e) => setEditedPriority(e.target.value as QuestionPriority)}
                   aria-label="優先度"
                   style={{
                     padding: '4px 8px',

--- a/src/services/nurseryDataStore.test.ts
+++ b/src/services/nurseryDataStore.test.ts
@@ -55,10 +55,6 @@ describe('NurseryDataStore (TDD Green Phase)', () => {
       // Red: まだ実装されていない機能のテスト
       const nurseryInput: CreateNurseryInput = {
         name: 'テスト保育園',
-        address: '東京都渋谷区1-1-1',
-        phoneNumber: '03-1234-5678',
-        website: 'https://test-nursery.jp',
-        notes: 'テスト用の保育園です',
       };
 
       // Green: 実装されたので成功することが期待される

--- a/src/stores/nurseryStore.test.ts
+++ b/src/stores/nurseryStore.test.ts
@@ -71,10 +71,6 @@ describe('NurseryStore (TDD Green Phase)', () => {
       // Green: 実装されたので成功することが期待される
       const newNurseryInput: CreateNurseryInput = {
         name: '新しい保育園',
-        address: '東京都新宿区2-2-2',
-        phoneNumber: '03-9876-5432',
-        website: 'https://new-nursery.jp',
-        notes: '新しく開園した保育園',
       };
 
       const mockNurseries: Nursery[] = [

--- a/src/utils/data.test.ts
+++ b/src/utils/data.test.ts
@@ -39,7 +39,7 @@ describe('データユーティリティ関数', () => {
     vi.setSystemTime(mockDate);
 
     // crypto.randomUUIDをモック
-    Object.defineProperty(global, 'crypto', {
+    Object.defineProperty(globalThis, 'crypto', {
       value: { randomUUID: mockGenerateId },
       writable: true,
     });

--- a/src/utils/errorOperations.test.ts
+++ b/src/utils/errorOperations.test.ts
@@ -602,8 +602,10 @@ describe('errorOperations', () => {
         );
         if (!result) {
           const error = new Error('Operation failed');
-          (error as AppError).code = 'OPERATION_FAILED';
-          (error as AppError).timestamp = new Date();
+          Object.assign(error, {
+            code: 'OPERATION_FAILED',
+            timestamp: new Date(),
+          } as Partial<AppError>);
           throw error;
         }
       };


### PR DESCRIPTION
## 概要
`npm run build`実行時に発生していたTypeScriptエラーを修正しました。

## 修正内容
- **NurseryCard.test.tsx**: 循環参照エラーを修正 (typeof nursery → Nursery型)
- **QuestionItem.tsx**: 型キャストエラーを修正 (QuestionPriorityインポート追加)
- **nurseryDataStore.test.ts/nurseryStore.test.ts**: 不要なaddressプロパティを削除
- **data.test.ts**: global → globalThisに変更
- **errorOperations.test.ts**: AppError型キャストエラーを修正

## 確認事項
- [x] `npm run build` が正常に完了
- [x] `npm run lint` でエラーなし
- [ ] テストの一部失敗あり（UIテスト関連、別Issueで対応予定）

## 関連Issue
テストの失敗については別途Issueを作成して対応予定です。