### PR TITLE
feat: 保育園情報のインライン編集機能とUI改善を実装

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -29,7 +29,7 @@ export const Layout = ({
         </Container>
       </Box>
 
-      <Container as="main" maxW="container.xl" py={8}>
+      <Container as="main" maxW="container.xl" py={4}>
         {children || <Outlet />}
       </Container>
     </Box>

--- a/src/components/NurseryDetailPage.test.tsx
+++ b/src/components/NurseryDetailPage.test.tsx
@@ -354,12 +354,92 @@ describe('NurseryDetailPage コンポーネント', () => {
     });
   });
 
+  describe('保育園編集機能', () => {
+    test('編集ボタンが表示される', () => {
+      renderWithProviders(<NurseryDetailPage />);
+
+      const editButton = screen.getByRole('button', { name: '編集' });
+      expect(editButton).toBeInTheDocument();
+    });
+
+    test('編集ボタンをクリックすると編集モードになる', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NurseryDetailPage />);
+
+      const editButton = screen.getByRole('button', { name: '編集' });
+      await user.click(editButton);
+
+      expect(screen.getByRole('button', { name: '保存' })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'キャンセル' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText('保育園名を入力してください')
+      ).toBeInTheDocument();
+    });
+
+    test('保育園名を編集して保存できる', async () => {
+      const user = userEvent.setup();
+      const mockUpdateNursery = vi.fn();
+
+      vi.mocked(useNurseryStore).mockReturnValue({
+        currentNursery: mockCurrentNursery,
+        loading: { isLoading: false },
+        error: null,
+        updateNursery: mockUpdateNursery,
+        addQuestion: vi.fn(),
+        updateQuestion: vi.fn(),
+        setCurrentNursery: vi.fn(),
+        clearError: vi.fn(),
+      });
+
+      renderWithProviders(<NurseryDetailPage />);
+
+      // 編集モードに切り替え
+      const editButton = screen.getByRole('button', { name: '編集' });
+      await user.click(editButton);
+
+      // 保育園名を変更
+      const nameInput =
+        screen.getByPlaceholderText('保育園名を入力してください');
+      await user.clear(nameInput);
+      await user.type(nameInput, '新しい保育園名');
+
+      // 保存
+      const saveButton = screen.getByRole('button', { name: '保存' });
+      await user.click(saveButton);
+
+      expect(mockUpdateNursery).toHaveBeenCalledWith('nursery-1', {
+        name: '新しい保育園名',
+        visitSessions: expect.any(Array),
+      });
+    });
+
+    test('キャンセルボタンで編集モードを終了できる', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<NurseryDetailPage />);
+
+      // 編集モードに切り替え
+      const editButton = screen.getByRole('button', { name: '編集' });
+      await user.click(editButton);
+
+      // キャンセル
+      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+      await user.click(cancelButton);
+
+      expect(screen.getByRole('button', { name: '編集' })).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: '保存' })
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe('アクセシビリティ', () => {
     test('見出しが適切に設定されている', () => {
       renderWithProviders(<NurseryDetailPage />);
 
       expect(
-        screen.getByRole('heading', { name: 'テスト保育園' })
+        screen.getByRole('heading', { name: '保育園詳細' })
       ).toBeInTheDocument();
     });
 

--- a/src/components/NurseryDetailPage.test.tsx
+++ b/src/components/NurseryDetailPage.test.tsx
@@ -83,6 +83,7 @@ describe('NurseryDetailPage コンポーネント', () => {
       addQuestion: vi.fn(),
       updateQuestion: vi.fn(),
       deleteQuestion: vi.fn(),
+      setCurrentNursery: vi.fn(),
       clearError: vi.fn(),
     });
   });
@@ -190,6 +191,7 @@ describe('NurseryDetailPage コンポーネント', () => {
         addQuestion: vi.fn(),
         updateQuestion: mockUpdateQuestion,
         deleteQuestion: vi.fn(),
+        setCurrentNursery: vi.fn(),
         clearError: vi.fn(),
       });
 
@@ -248,6 +250,7 @@ describe('NurseryDetailPage コンポーネント', () => {
         addQuestion: mockAddQuestion,
         updateQuestion: vi.fn(),
         deleteQuestion: vi.fn(),
+        setCurrentNursery: vi.fn(),
         clearError: vi.fn(),
       });
 
@@ -326,6 +329,7 @@ describe('NurseryDetailPage コンポーネント', () => {
         addQuestion: vi.fn(),
         updateQuestion: vi.fn(),
         deleteQuestion: vi.fn(),
+        setCurrentNursery: vi.fn(),
         clearError: vi.fn(),
       });
 
@@ -343,6 +347,7 @@ describe('NurseryDetailPage コンポーネント', () => {
         addQuestion: vi.fn(),
         updateQuestion: vi.fn(),
         deleteQuestion: vi.fn(),
+        setCurrentNursery: vi.fn(),
         clearError: vi.fn(),
       });
 
@@ -389,6 +394,7 @@ describe('NurseryDetailPage コンポーネント', () => {
         updateNursery: mockUpdateNursery,
         addQuestion: vi.fn(),
         updateQuestion: vi.fn(),
+        deleteQuestion: vi.fn(),
         setCurrentNursery: vi.fn(),
         clearError: vi.fn(),
       });

--- a/src/components/NurseryHeader.tsx
+++ b/src/components/NurseryHeader.tsx
@@ -2,23 +2,13 @@
  * 保育園詳細ページヘッダーコンポーネント
  */
 
-import { Button, Heading, Box } from '@chakra-ui/react';
+import { Button, Heading, Spacer } from '@chakra-ui/react';
 
 interface NurseryHeaderProps {
   onBack: () => void;
-  isEditing: boolean;
-  onEdit: () => void;
-  onSave: () => void;
-  onCancel: () => void;
 }
 
-export const NurseryHeader = ({
-  onBack,
-  isEditing,
-  onEdit,
-  onSave,
-  onCancel,
-}: NurseryHeaderProps) => {
+export const NurseryHeader = ({ onBack }: NurseryHeaderProps) => {
   return (
     <>
       <Button
@@ -38,32 +28,7 @@ export const NurseryHeader = ({
       >
         保育園詳細
       </Heading>
-      {isEditing ? (
-        <Box display="flex" gap={2}>
-          <Button
-            size={{ base: 'sm', md: 'md' }}
-            colorScheme="brand"
-            onClick={onSave}
-          >
-            保存
-          </Button>
-          <Button
-            size={{ base: 'sm', md: 'md' }}
-            variant="ghost"
-            onClick={onCancel}
-          >
-            キャンセル
-          </Button>
-        </Box>
-      ) : (
-        <Button
-          size={{ base: 'sm', md: 'md' }}
-          variant="ghost"
-          onClick={onEdit}
-        >
-          編集
-        </Button>
-      )}
+      <Spacer />
     </>
   );
 };

--- a/src/components/NurseryHeader.tsx
+++ b/src/components/NurseryHeader.tsx
@@ -5,11 +5,20 @@
 import { Button, Heading, Box } from '@chakra-ui/react';
 
 interface NurseryHeaderProps {
-  nurseryName: string;
   onBack: () => void;
+  isEditing: boolean;
+  onEdit: () => void;
+  onSave: () => void;
+  onCancel: () => void;
 }
 
-export const NurseryHeader = ({ nurseryName, onBack }: NurseryHeaderProps) => {
+export const NurseryHeader = ({
+  onBack,
+  isEditing,
+  onEdit,
+  onSave,
+  onCancel,
+}: NurseryHeaderProps) => {
   return (
     <>
       <Button
@@ -27,9 +36,34 @@ export const NurseryHeader = ({ nurseryName, onBack }: NurseryHeaderProps) => {
         flex={1}
         textAlign="center"
       >
-        {nurseryName}
+        保育園詳細
       </Heading>
-      <Box minW={{ base: '60px', md: '80px' }} /> {/* スペーサー */}
+      {isEditing ? (
+        <Box display="flex" gap={2}>
+          <Button
+            size={{ base: 'sm', md: 'md' }}
+            colorScheme="brand"
+            onClick={onSave}
+          >
+            保存
+          </Button>
+          <Button
+            size={{ base: 'sm', md: 'md' }}
+            variant="ghost"
+            onClick={onCancel}
+          >
+            キャンセル
+          </Button>
+        </Box>
+      ) : (
+        <Button
+          size={{ base: 'sm', md: 'md' }}
+          variant="ghost"
+          onClick={onEdit}
+        >
+          編集
+        </Button>
+      )}
     </>
   );
 };

--- a/src/components/NurseryInfo.tsx
+++ b/src/components/NurseryInfo.tsx
@@ -62,12 +62,12 @@ export const NurseryInfo = ({
   return (
     <Box
       bg="gray.50"
-      p={{ base: 4, md: 6 }}
+      p={0}
       borderRadius="lg"
       border="1px"
       borderColor="gray.200"
     >
-      <VStack align="stretch" gap={{ base: 3, md: 4 }}>
+      <VStack align="stretch" gap={{ base: 2, md: 3 }}>
         {/* 見学予定日 */}
         <Box flex={1}>
           <Text

--- a/src/components/NurseryInfoCard.tsx
+++ b/src/components/NurseryInfoCard.tsx
@@ -1,0 +1,126 @@
+/**
+ * 保育園情報カードコンポーネント
+ * ホームページのNurseryCardデザインを統合した編集可能なカード
+ */
+
+import { Box, Text, VStack, Input } from '@chakra-ui/react';
+import { useMemo } from 'react';
+import type { Question } from '../types/data';
+
+interface NurseryInfoCardProps {
+  nurseryName: string;
+  visitDate: Date | null;
+  questions: Question[];
+  isEditing?: boolean;
+  editingName?: string;
+  newVisitDate?: string;
+  onNameChange?: (value: string) => void;
+  onVisitDateChange?: (value: string) => void;
+}
+
+/**
+ * 日付フォーマッター（NurseryCardと同じ形式）
+ */
+const formatDate = (date: Date): string => {
+  return `${date.getFullYear()}/${date.getMonth() + 1}/${date.getDate()}`;
+};
+
+/**
+ * 質問進捗計算
+ */
+const getQuestionProgress = (
+  questions: Question[]
+): { text: string; percentage: number } => {
+  const answeredCount = questions.filter((q) => q.isAnswered).length;
+  const percentage =
+    questions.length > 0 ? (answeredCount / questions.length) * 100 : 0;
+  return {
+    text: `${answeredCount}/${questions.length}`,
+    percentage,
+  };
+};
+
+export const NurseryInfoCard = ({
+  nurseryName,
+  visitDate,
+  questions,
+  isEditing = false,
+  editingName = '',
+  newVisitDate = '',
+  onNameChange,
+  onVisitDateChange,
+}: NurseryInfoCardProps) => {
+  // 進捗データをメモ化してパフォーマンス最適化
+  const progressData = useMemo(
+    () => getQuestionProgress(questions),
+    [questions]
+  );
+
+  return (
+    <Box
+      p={4}
+      borderWidth={1}
+      borderRadius="md"
+      bg="white"
+      shadow="sm"
+      transition="all 0.2s ease-in-out"
+      _hover={{
+        shadow: 'md',
+      }}
+    >
+      <VStack align="stretch" gap={3}>
+        {/* 保育園名 */}
+        {isEditing ? (
+          <Input
+            value={editingName}
+            onChange={(e) => onNameChange?.(e.target.value)}
+            placeholder="保育園名を入力してください"
+            fontSize="lg"
+            fontWeight="bold"
+            bg="white"
+            borderColor="brand.300"
+            _focus={{ borderColor: 'brand.500', shadow: 'outline' }}
+          />
+        ) : (
+          <Text
+            fontWeight="bold"
+            fontSize="lg"
+            color="gray.800"
+            textAlign="left"
+            lineHeight="1.3"
+          >
+            {nurseryName}
+          </Text>
+        )}
+
+        {/* 詳細情報部分: 見学日と質問進捗 */}
+        <VStack align="stretch" gap={1}>
+          {isEditing ? (
+            <VStack align="stretch" gap={1}>
+              <Text color="gray.600" fontSize="sm" fontWeight="medium">
+                見学日
+              </Text>
+              <Input
+                type="date"
+                value={newVisitDate}
+                onChange={(e) => onVisitDateChange?.(e.target.value)}
+                size="sm"
+                bg="white"
+                borderColor="brand.300"
+                _focus={{ borderColor: 'brand.500', shadow: 'outline' }}
+              />
+            </VStack>
+          ) : (
+            <Text color="gray.600" fontSize="sm" textAlign="left">
+              見学日: {visitDate ? formatDate(visitDate) : '未設定'}
+            </Text>
+          )}
+
+          <Text color="gray.600" fontSize="sm" textAlign="left">
+            質問進捗: {progressData.text}
+          </Text>
+        </VStack>
+      </VStack>
+    </Box>
+  );
+};

--- a/src/components/NurseryNameSection.test.tsx
+++ b/src/components/NurseryNameSection.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders } from '../test/test-utils';
+import { NurseryNameSection } from './NurseryNameSection';
+
+describe('NurseryNameSection', () => {
+  const defaultProps = {
+    nurseryName: 'テスト保育園',
+    isEditing: false,
+    editingName: '',
+    onNameChange: vi.fn(),
+  };
+
+  describe('通常表示モード', () => {
+    it('保育園名が表示される', () => {
+      renderWithProviders(<NurseryNameSection {...defaultProps} />);
+
+      expect(screen.getByText('テスト保育園')).toBeInTheDocument();
+    });
+
+    it('入力フィールドは表示されない', () => {
+      renderWithProviders(<NurseryNameSection {...defaultProps} />);
+
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('編集モード', () => {
+    const editingProps = {
+      ...defaultProps,
+      isEditing: true,
+      editingName: 'テスト保育園',
+    };
+
+    it('入力フィールドが表示される', () => {
+      renderWithProviders(<NurseryNameSection {...editingProps} />);
+
+      const input = screen.getByRole('textbox');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveValue('テスト保育園');
+    });
+
+    it('保育園名のテキストは表示されない', () => {
+      renderWithProviders(<NurseryNameSection {...editingProps} />);
+
+      expect(screen.queryByText('テスト保育園')).not.toBeInTheDocument();
+    });
+
+    it('入力値が変更されるとonNameChangeが呼ばれる', async () => {
+      const user = userEvent.setup();
+      const onNameChange = vi.fn();
+
+      renderWithProviders(
+        <NurseryNameSection
+          {...defaultProps}
+          isEditing={true}
+          editingName=""
+          onNameChange={onNameChange}
+        />
+      );
+
+      const input = screen.getByRole('textbox');
+      await user.type(input, 'A');
+
+      // onNameChangeが呼ばれることを確認
+      expect(onNameChange).toHaveBeenCalledWith('A');
+    });
+
+    it('プレースホルダーが正しく表示される', () => {
+      renderWithProviders(
+        <NurseryNameSection {...editingProps} editingName="" />
+      );
+
+      const input = screen.getByPlaceholderText('保育園名を入力してください');
+      expect(input).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/NurseryNameSection.tsx
+++ b/src/components/NurseryNameSection.tsx
@@ -1,0 +1,63 @@
+/**
+ * 保育園名表示・編集セクションコンポーネント
+ */
+
+import { Box, Text, Input } from '@chakra-ui/react';
+
+interface NurseryNameSectionProps {
+  nurseryName: string;
+  isEditing: boolean;
+  editingName: string;
+  onNameChange: (value: string) => void;
+}
+
+export const NurseryNameSection = ({
+  nurseryName,
+  isEditing,
+  editingName,
+  onNameChange,
+}: NurseryNameSectionProps) => {
+  if (isEditing) {
+    return (
+      <Box
+        p={0}
+        borderRadius="lg"
+        border="2px"
+        borderColor="brand.200"
+        bg="brand.50"
+      >
+        <Input
+          value={editingName}
+          onChange={(e) => onNameChange(e.target.value)}
+          placeholder="保育園名を入力してください"
+          size={{ base: 'md', md: 'lg' }}
+          fontSize={{ base: 'lg', md: 'xl' }}
+          fontWeight="bold"
+          bg="white"
+          borderColor="brand.300"
+          _focus={{ borderColor: 'brand.500', shadow: 'outline' }}
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      p={0}
+      borderRadius="lg"
+      border="1px"
+      borderColor="gray.200"
+      bg="white"
+      textAlign="center"
+    >
+      <Text
+        fontSize={{ base: 'lg', md: 'xl' }}
+        fontWeight="bold"
+        color="teal.600"
+        textAlign="center"
+      >
+        {nurseryName}
+      </Text>
+    </Box>
+  );
+};

--- a/src/components/QuestionAddForm.tsx
+++ b/src/components/QuestionAddForm.tsx
@@ -23,7 +23,7 @@ export const QuestionAddForm = ({
     return (
       <VStack
         align="stretch"
-        p={0}
+        p={4}
         border="2px"
         borderColor="brand.200"
         borderRadius="lg"

--- a/src/components/QuestionAddForm.tsx
+++ b/src/components/QuestionAddForm.tsx
@@ -23,7 +23,7 @@ export const QuestionAddForm = ({
     return (
       <VStack
         align="stretch"
-        p={{ base: 4, md: 5 }}
+        p={0}
         border="2px"
         borderColor="brand.200"
         borderRadius="lg"


### PR DESCRIPTION
## Summary
保育園詳細ページに編集機能を追加し、UI/UXの大幅な改善を実装しました。

## Features
- 保育園名と見学日のインライン編集機能
- カード外に編集ボタンを配置し、カード内でインライン編集を実現
- 見学セッションが未設定の場合の新規作成に対応
- 誤タップ防止のための適切なボタン配置

## UI/UX Improvements
- 保育園情報エリアと質問エリアの明確な分離（Separator追加）
- 進捗バーを削除し、テキスト表示のみに変更（より直感的）
- padding調整によるコンパクトなレイアウト
- ボタン位置の一貫性（編集→保存・キャンセルで位置が変わらない）

## Test plan
- [x] 編集ボタンをクリックして編集モードに切り替え
- [x] 保育園名を変更して保存
- [x] 見学日を設定（未設定→設定）
- [x] 見学日を変更（設定済み→変更）
- [x] キャンセルボタンで編集を中止
- [x] 誤タップ防止のための余白確認
- [x] 質問進捗のテキスト表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)