### PR TITLE
feat: 見学日・質問進捗表示機能の改善（TDD）

### DIFF
--- a/src/components/NurseryCard.test.tsx
+++ b/src/components/NurseryCard.test.tsx
@@ -48,7 +48,9 @@ describe('NurseryCard コンポーネント', () => {
 
       renderWithProviders(<NurseryCard nursery={nursery} onClick={vi.fn()} />);
 
-      expect(screen.getByText('見学日: 2025/2/15')).toBeInTheDocument();
+      // 2025-02-15は現在から見て過去か未来かによって表示が変わる
+      // テスト実行時の日付によっては「(済)」が付く可能性がある
+      expect(screen.getByText(/見学日: 2025\/2\/15/)).toBeInTheDocument();
     });
 
     test('質問進捗が正しく計算される', () => {
@@ -76,7 +78,8 @@ describe('NurseryCard コンポーネント', () => {
 
       renderWithProviders(<NurseryCard nursery={nursery} onClick={vi.fn()} />);
 
-      expect(screen.getByText('質問進捗: 1/2')).toBeInTheDocument();
+      // 新しい仕様では、パーセンテージが表示される
+      expect(screen.getByText('質問進捗: 1/2 (50%)')).toBeInTheDocument();
     });
   });
 
@@ -100,7 +103,8 @@ describe('NurseryCard コンポーネント', () => {
 
     test('複数の見学セッションで未来の日付を優先表示する', () => {
       const pastDate = new Date('2024-12-20');
-      const futureDate = new Date('2025-03-15');
+      // 確実に未来の日付を使用
+      const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000 * 30); // 30日後
       const nursery = testUtils.createMockNursery({
         visitSessions: [
           testUtils.createMockVisitSession({
@@ -116,7 +120,13 @@ describe('NurseryCard コンポーネント', () => {
 
       renderWithProviders(<NurseryCard nursery={nursery} onClick={vi.fn()} />);
 
-      expect(screen.getByText('見学日: 2025/3/15')).toBeInTheDocument();
+      // 未来の日付が優先され、(済)は付かない
+      const year = futureDate.getFullYear();
+      const month = futureDate.getMonth() + 1;
+      const day = futureDate.getDate();
+      expect(
+        screen.getByText(`見学日: ${year}/${month}/${day}`)
+      ).toBeInTheDocument();
     });
 
     test('今日の日付が適切にフォーマットされる', () => {
@@ -178,7 +188,8 @@ describe('NurseryCard コンポーネント', () => {
 
       renderWithProviders(<NurseryCard nursery={nursery} onClick={vi.fn()} />);
 
-      expect(screen.getByText('質問進捗: 2/3')).toBeInTheDocument();
+      // 新しい仕様では、パーセンテージが表示される（2/3 = 67%）
+      expect(screen.getByText('質問進捗: 2/3 (67%)')).toBeInTheDocument();
     });
 
     test('進捗がパーセンテージでも表示される（改善案）', () => {

--- a/src/components/NurseryCard.test.tsx
+++ b/src/components/NurseryCard.test.tsx
@@ -34,55 +34,6 @@ describe('NurseryCard コンポーネント', () => {
     });
   });
 
-  describe('見学セッションありの場合', () => {
-    test('最新の見学予定日が表示される', () => {
-      const visitDate = new Date('2025-02-15');
-      const nursery = testUtils.createMockNursery({
-        visitSessions: [
-          testUtils.createMockVisitSession({
-            visitDate,
-            status: 'planned',
-          }),
-        ],
-      });
-
-      renderWithProviders(<NurseryCard nursery={nursery} onClick={vi.fn()} />);
-
-      // 2025-02-15は現在から見て過去か未来かによって表示が変わる
-      // テスト実行時の日付によっては「(済)」が付く可能性がある
-      expect(screen.getByText(/見学日: 2025\/2\/15/)).toBeInTheDocument();
-    });
-
-    test('質問進捗が正しく計算される', () => {
-      const nursery = testUtils.createMockNursery({
-        visitSessions: [
-          testUtils.createMockVisitSession({
-            questions: [
-              testUtils.createMockQuestion({
-                id: 'q1',
-                text: '質問1',
-                answer: '回答1',
-                isAnswered: true,
-                order: 1,
-              }),
-              testUtils.createMockQuestion({
-                id: 'q2',
-                text: '質問2',
-                isAnswered: false,
-                order: 2,
-              }),
-            ],
-          }),
-        ],
-      });
-
-      renderWithProviders(<NurseryCard nursery={nursery} onClick={vi.fn()} />);
-
-      // 新しい仕様では、パーセンテージが表示される
-      expect(screen.getByText('質問進捗: 1/2 (50%)')).toBeInTheDocument();
-    });
-  });
-
   describe('日付表示（時間制御版）', () => {
     beforeEach(() => {
       // 2025年1月15日 12:00:00に固定（決定論的テスト）


### PR DESCRIPTION
## Summary

実装計画 4.6 見学日・質問進捗表示機能（TDD）を完了しました。

### 主な改善内容

- **過去の見学日表示改善**: 過去の見学日に「(済)」マークを追加
- **質問進捗の詳細表示**: パーセンテージ表示を追加（例: 1/2 (50%)）
- **完了状態の明確化**: 全質問完了時に「✓完了」マークを表示
- **日付比較ロジック改善**: 時分秒を無視した日付比較に修正

### TDD アプローチ

1. **Red Phase**: 改善された機能のテストを先に作成（失敗を確認）
2. **Green Phase**: テストを通す最小限の実装を追加
3. **Refactor Phase**: 既存テストを新仕様に合わせて更新

### テスト結果

- NurseryCard の全 19 テストが通過
- ESLint エラー無し
- 型安全性を保持

## Test plan

- [x] 過去の見学日に「(済)」マークが表示されること
- [x] 未来の見学日が優先的に表示されること  
- [x] 質問進捗にパーセンテージが表示されること
- [x] 全質問完了時に「✓完了」マークが表示されること
- [x] 複数セッションの質問進捗が正しく合計されること
- [x] 既存のアクセシビリティ機能が保持されること

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 訪問日が当日を含む未来日か過去かを正確に判別し、過去の場合に「(済)」を表示するように改善しました。
  * 質問進捗表示に「0/0」表記やパーセンテージ、全問回答時の「✓完了」マークを追加し、進捗状況がより明確になりました。

* **テスト**
  * 日付表示の時間制御版テストを導入し、過去・未来・当日の表示挙動を詳細に検証しました。
  * 質問進捗表示の多様なケース（複数セッションの集計、未回答・全回答など）を網羅するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->