### PR TITLE
fix: VercelでのSPAルーティング問題を修正

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要
Vercelで保育園詳細ページをリロードすると404エラーになる問題を修正しました。

## 問題
- `/nursery/:id`などの動的ルートにアクセスした状態でページをリロードすると404エラーが発生
- VercelがSPAのクライアントサイドルーティングを正しく処理できていなかったため

## 解決策
`vercel.json`を追加し、全てのルートを`index.html`にリライトする設定を追加しました。これにより：
- リロード時もReact Routerが正しくルーティングを処理
- 保育園詳細ページなどの動的ルートでも正常に表示されるように

## テスト方法
1. Vercelにデプロイ
2. 保育園詳細ページ（`/nursery/xxx`）にアクセス
3. ブラウザでリロード（F5）を実行
4. 404エラーではなく、正しく保育園詳細ページが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Vercelデプロイメント用の新しいルーティング設定を追加し、すべてのリクエストを `/index.html` にリライトしてクライアントサイドルーティングを有効化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->