### PR TITLE
docs: 設計書と実装の整合性を改善

### DIFF
--- a/.kiro/specs/nursery-visit-qa-app/design.md
+++ b/.kiro/specs/nursery-visit-qa-app/design.md
@@ -86,6 +86,7 @@
 - **VisitSessionForm**: 見学セッション作成・編集フォーム
 - **QuestionItem**: 個別質問表示・編集
 - **AnswerInput**: 回答入力フォーム
+- **NotesSection**: 見学メモ入力（文字数制限・自動保存機能付き）
 - **TemplateSelector**: 質問テンプレート選択
 - **SyncIndicator**: 同期状況表示
 - **OfflineIndicator**: オフライン状態表示
@@ -117,7 +118,7 @@ interface VisitSession {
   visitDate: Date;
   status: 'planned' | 'completed' | 'cancelled';
   questions: Question[];
-  notes?: string;
+  notes?: string; // 見学メモ（2000文字制限・自動保存・リアルタイム警告機能付き）
   sharedWith?: string[]; // 共有相手のID
   createdAt: Date;
   updatedAt: Date;
@@ -132,11 +133,11 @@ interface Question {
   text: string;
   answer?: string;
   isAnswered: boolean;
-  priority: 'high' | 'medium' | 'low';
   category?: string;
-  order: number;
   answeredBy?: string; // 回答者ID
   answeredAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
 }
 ```
 
@@ -311,9 +312,7 @@ CREATE TABLE questions (
   text TEXT NOT NULL,
   answer TEXT,
   is_answered INTEGER DEFAULT 0, -- SQLite boolean
-  priority TEXT CHECK (priority IN ('high', 'medium', 'low')) DEFAULT 'medium',
   category TEXT,
-  order_index INTEGER NOT NULL,
   answered_by TEXT REFERENCES profiles(id),
   answered_at DATETIME,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -333,7 +332,6 @@ CREATE TABLE question_list_shares (
 -- インデックス（パフォーマンス最適化）
 CREATE INDEX idx_question_lists_owner ON question_lists(owner_id);
 CREATE INDEX idx_questions_list ON questions(list_id);
-CREATE INDEX idx_questions_order ON questions(list_id, order_index);
 CREATE INDEX idx_shares_list ON question_list_shares(list_id);
 CREATE INDEX idx_shares_user ON question_list_shares(shared_with);
 ```

--- a/.kiro/specs/nursery-visit-qa-app/tasks.md
+++ b/.kiro/specs/nursery-visit-qa-app/tasks.md
@@ -123,6 +123,13 @@
   - **Refactor**: 日付フォーマット、進捗計算の改善
   - _要件: 1.6, 1.7_
 
+- [ ] 4.7 @deprecated型の段階的削除（保育園中心設計への完全移行）
+  - **Phase 1**: QuestionListCreator、QuestionList コンポーネントをNursery中心設計に変更
+  - **Phase 2**: @deprecatedインターフェース（QuestionList、CreateQuestionListInput等）の削除
+  - **Phase 3**: 関連するhooks、stores、servicesの削除
+  - **Verification**: 全てのテストが新設計で動作することを確認
+  - _要件: 保育園中心設計への完全移行_
+
 ### 5. データセキュリティ機能
 
 - [ ] 5.1 データ暗号化の実装

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -134,10 +134,6 @@ export const AppRouter = () => {
     <Routes>
       <Route element={<Layout />}>
         <Route path="/" element={<HomePage />} />
-        <Route
-          path="/nursery"
-          element={<Text>保育園管理ページ（実装中）</Text>}
-        />
         <Route path="*" element={<NotFoundPage />} />
       </Route>
       {/* NurseryDetailPageは独自のLayoutを使用するため、別ルートに */}


### PR DESCRIPTION
## Summary

設計書と実装の不整合を修正し、設計ドキュメントを最新の実装状態に合わせました。

- priority機能を設計書から削除（実装では既に削除済み）
- NotesSection仕様を設計書に追加（実装は完了済み）
- 不要な/nurseryルートを削除
- @deprecated型の段階的削除計画を追加

## Changes

### 設計書の修正 (.kiro/specs/nursery-visit-qa-app/design.md)
- `Question`インターフェースから`priority`プロパティを削除
- データベーススキーマから`priority`フィールドと関連インデックスを削除
- `VisitSession.notes`にNotesSection機能の仕様をコメントで追加
- コンポーネント設計に`NotesSection`を追加

### Router.tsxの整理
- 実装中ステータスの`/nursery`ルートを削除
- シンプルUI設計に合わせてルーティングを整理

### 実装計画の更新 (.kiro/specs/nursery-visit-qa-app/tasks.md)
- @deprecated型の段階的削除計画（Task 4.7）を追加
- Phase 1-3の詳細な削除手順を記載

## Test plan

- [x] 設計書の記述が既存のスタイルと統一されている
- [x] priority機能の記述が完全に削除されている
- [x] Router.tsxから不要なルートが削除されている
- [x] 実装計画に@deprecated型削除タスクが追加されている

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 文字数制限（2000文字）と自動保存機能付きの訪問メモ入力用UIコンポーネント「NotesSection」を追加しました。

* **改善**
  * 質問データの作成日時・更新日時の表示に対応しました。

* **仕様変更**
  * 質問の優先度・並び順指定機能を削除しました。
  * 「/nursery」ページへのルートを削除しました。

* **ドキュメント**
  * 保育園中心設計への完全移行に向けた段階的なタスクを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->