### PR TITLE
fix: 質問編集時にテキストの変更が保存されない問題を修正

### DIFF
--- a/src/components/NurseryDetailPage.test.tsx
+++ b/src/components/NurseryDetailPage.test.tsx
@@ -207,6 +207,7 @@ describe('NurseryDetailPage コンポーネント', () => {
         'session-1',
         'question-1',
         {
+          text: '保育時間は何時から何時までですか？',
           answer: '7時から19時まで',
           isAnswered: true,
         }

--- a/src/components/NurseryDetailPage.tsx
+++ b/src/components/NurseryDetailPage.tsx
@@ -85,12 +85,14 @@ export const NurseryDetailPage = () => {
     if (!session) return;
 
     await updateQuestion(currentNursery.id, session.id, editingQuestionId, {
+      text: editingQuestionText,
       answer: editingAnswer,
       isAnswered: editingAnswer.trim() !== '',
     });
 
     setEditingQuestionId(null);
     setEditingAnswer('');
+    setEditingQuestionText('');
   };
 
   const handleAddQuestion = async () => {


### PR DESCRIPTION
## 概要
質問編集時に質問テキストの変更が保存されない問題を修正しました。

## 問題
- 質問の編集画面で質問テキストを変更して保存しても、変更前の値に戻ってしまう
- 回答の変更は正しく保存されるが、質問テキストの変更が反映されない

## 修正内容
`NurseryDetailPage`コンポーネントの`handleSaveAnswer`関数で、`updateQuestion`に`editingQuestionText`も渡すように修正しました。

```typescript
await updateQuestion(currentNursery.id, session.id, editingQuestionId, {
  text: editingQuestionText,  // この行を追加
  answer: editingAnswer,
  isAnswered: editingAnswer.trim() \!== '',
});
```

また、編集状態のリセット時に`editingQuestionText`もクリアするようにしました。

## テスト
- ✅ 既存のテストケースを更新し、すべてのテストが通過することを確認
- ✅ ESLintでエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 回答を保存する際に質問文も正しく更新されるようになりました。
  * 回答保存後、編集中の質問文がリセットされるようになりました。

* **テスト**
  * テストケースに質問文の検証が追加され、より正確な動作確認が行われるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->