### PR TITLE
feat: refactor header components for better reusability

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,31 +1,41 @@
-import { Box, Container, Heading, HStack } from '@chakra-ui/react';
+import { Box, Container } from '@chakra-ui/react';
 import { Outlet } from 'react-router-dom';
 import type { ReactNode } from 'react';
+import { NurseryHeader } from './NurseryHeader';
+import type { HeaderButton, HeaderVariant } from '../types/header';
 
 interface LayoutProps {
   children?: ReactNode;
-  headerContent?: ReactNode;
+  headerTitle?: string;
+  headerVariant?: HeaderVariant;
+  leftButton?: HeaderButton;
+  rightButton?: HeaderButton;
   showDefaultTitle?: boolean;
 }
 
 export const Layout = ({
   children,
-  headerContent,
+  headerTitle,
+  headerVariant = 'centered',
+  leftButton,
+  rightButton,
   showDefaultTitle = true,
 }: LayoutProps) => {
+  const shouldShowHeader = headerTitle || showDefaultTitle;
+  const title = headerTitle || '保育園見学質問リスト';
+
   return (
     <Box minH="100vh" bg="gray.50">
       <Box as="header" bg="white" shadow="sm">
         <Container maxW="container.xl" py={4}>
-          {headerContent ? (
-            <HStack justify="space-between" align="center">
-              {headerContent}
-            </HStack>
-          ) : showDefaultTitle ? (
-            <Heading as="h1" size="lg" color="teal.600" textAlign="center">
-              保育園見学質問リスト
-            </Heading>
-          ) : null}
+          {shouldShowHeader && (
+            <NurseryHeader
+              title={title}
+              variant={headerVariant}
+              leftButton={leftButton}
+              rightButton={rightButton}
+            />
+          )}
         </Container>
       </Box>
 

--- a/src/components/NurseryCreatorPage.tsx
+++ b/src/components/NurseryCreatorPage.tsx
@@ -3,7 +3,6 @@
  * ヘッダーとレイアウトを含む完全なページコンポーネント
  */
 
-import { Box, HStack, Heading, IconButton } from '@chakra-ui/react';
 import { IoClose } from 'react-icons/io5';
 import { Layout } from './Layout';
 import { NurseryCreator } from './NurseryCreator/NurseryCreator';
@@ -15,24 +14,14 @@ interface NurseryCreatorPageProps {
 export const NurseryCreatorPage = ({ onCancel }: NurseryCreatorPageProps) => {
   return (
     <Layout
-      headerContent={
-        <HStack justify="space-between" align="center" w="full">
-          <IconButton
-            onClick={onCancel}
-            variant="ghost"
-            aria-label="閉じる"
-            size="md"
-            borderRadius="full"
-            _hover={{ bg: 'gray.100' }}
-          >
-            <IoClose />
-          </IconButton>
-          <Heading as="h1" size="md" color="teal.600">
-            新しい保育園を追加
-          </Heading>
-          <Box w="40px" /> {/* スペーサー（閉じるボタンと同じ幅） */}
-        </HStack>
-      }
+      headerTitle="新しい保育園を追加"
+      headerVariant="with-buttons"
+      leftButton={{
+        icon: <IoClose />,
+        onClick: onCancel,
+        variant: 'ghost',
+        'aria-label': '閉じる',
+      }}
       showDefaultTitle={false}
     >
       <NurseryCreator onCancel={onCancel} />

--- a/src/components/NurseryDetailPage.tsx
+++ b/src/components/NurseryDetailPage.tsx
@@ -2,6 +2,7 @@
  * 保育園詳細画面コンポーネント
  * リファクタリング: 責務別にコンポーネントを分割
  */
+import { IoChevronBack } from 'react-icons/io5';
 
 import {
   Box,
@@ -16,7 +17,6 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useNurseryStore } from '../stores/nurseryStore';
 import { Layout } from './Layout';
-import { NurseryHeader } from './NurseryHeader';
 import { NurseryInfoCard } from './NurseryInfoCard';
 import { QuestionAddForm } from './QuestionAddForm';
 import { QuestionsSection } from './QuestionsSection';
@@ -155,7 +155,7 @@ export const NurseryDetailPage = () => {
   // ローディング状態
   if (loading.isLoading || (nurseryId && !currentNursery && !error)) {
     return (
-      <Layout headerContent={<Box />} showDefaultTitle={false}>
+      <Layout showDefaultTitle={false}>
         <Box textAlign="center" py={8}>
           <Spinner size="lg" color="brand.500" />
           <Text mt={4} color="gray.600">
@@ -169,7 +169,7 @@ export const NurseryDetailPage = () => {
   // エラー状態
   if (error || (!currentNursery && nurseryId)) {
     return (
-      <Layout headerContent={<Box />} showDefaultTitle={false}>
+      <Layout showDefaultTitle={false}>
         <Box textAlign="center" py={8}>
           <Text color="red.500" fontSize="lg" mb={4}>
             {error?.message || '保育園が見つかりません'}
@@ -190,7 +190,7 @@ export const NurseryDetailPage = () => {
   // nurseryIdがないか、currentNurseryがない場合は404扱い
   if (!nurseryId || !currentNursery) {
     return (
-      <Layout headerContent={<Box />} showDefaultTitle={false}>
+      <Layout showDefaultTitle={false}>
         <Box textAlign="center" py={8}>
           <Text color="red.500" fontSize="lg" mb={4}>
             保育園が見つかりません
@@ -206,7 +206,13 @@ export const NurseryDetailPage = () => {
 
   return (
     <Layout
-      headerContent={<NurseryHeader onBack={handleBack} />}
+      headerTitle="保育園詳細"
+      headerVariant="with-buttons"
+      leftButton={{
+        icon: <IoChevronBack />,
+        onClick: handleBack,
+        variant: 'ghost',
+      }}
       showDefaultTitle={false}
     >
       <Box p={0} maxW="4xl" mx="auto">

--- a/src/components/NurseryHeader.test.tsx
+++ b/src/components/NurseryHeader.test.tsx
@@ -1,0 +1,590 @@
+/**
+ * NurseryHeader コンポーネントのテスト
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IoClose, IoArrowBack } from 'react-icons/io5';
+import { NurseryHeader } from './NurseryHeader';
+import type { HeaderButton } from '../types/header';
+import { renderWithProviders as render } from '../test/test-utils';
+
+describe('NurseryHeader', () => {
+  describe('基本表示', () => {
+    it('タイトルが表示される', () => {
+      render(<NurseryHeader title="テストタイトル" />);
+
+      expect(
+        screen.getByRole('heading', { name: 'テストタイトル' })
+      ).toBeInTheDocument();
+    });
+
+    it('タイトルが正しいHTMLレベルで表示される', () => {
+      render(<NurseryHeader title="テストタイトル" />);
+
+      const heading = screen.getByRole('heading', { name: 'テストタイトル' });
+      expect(heading.tagName).toBe('H1');
+    });
+
+    it('タイトルが中央揃えで表示される', () => {
+      render(<NurseryHeader title="テストタイトル" />);
+
+      const heading = screen.getByRole('heading', { name: 'テストタイトル' });
+      expect(heading).toHaveStyle({ textAlign: 'center' });
+    });
+
+    it('タイトルに適切なスタイルが設定される', () => {
+      render(<NurseryHeader title="テストタイトル" />);
+
+      const heading = screen.getByRole('heading', { name: 'テストタイトル' });
+      // コンポーネントが正しくレンダリングされることを確認
+      expect(heading).toBeInTheDocument();
+      expect(heading).toHaveClass('chakra-heading');
+    });
+  });
+
+  describe('variant="centered"', () => {
+    it('中央寄せレイアウトでタイトルのみが表示される', () => {
+      render(<NurseryHeader title="中央タイトル" variant="centered" />);
+
+      expect(
+        screen.getByRole('heading', { name: '中央タイトル' })
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('ボタンが指定されても中央寄せの場合は表示されない', () => {
+      const leftButton: HeaderButton = {
+        text: '戻る',
+        onClick: vi.fn(),
+      };
+
+      render(
+        <NurseryHeader
+          title="中央タイトル"
+          variant="centered"
+          leftButton={leftButton}
+        />
+      );
+
+      expect(
+        screen.getByRole('heading', { name: '中央タイトル' })
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('variant="with-buttons"（デフォルト）', () => {
+    it('ボタンなしでもタイトルが表示される', () => {
+      render(
+        <NurseryHeader title="ボタンなしタイトル" variant="with-buttons" />
+      );
+
+      expect(
+        screen.getByRole('heading', { name: 'ボタンなしタイトル' })
+      ).toBeInTheDocument();
+    });
+
+    it('variantを指定しなくてもwith-buttonsがデフォルトになる', () => {
+      const leftButton: HeaderButton = {
+        text: 'テストボタン',
+        onClick: vi.fn(),
+      };
+
+      render(
+        <NurseryHeader title="デフォルトタイトル" leftButton={leftButton} />
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'テストボタン' })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('左ボタン（leftButton）', () => {
+    describe('テキストボタン', () => {
+      it('テキストボタンが表示される', () => {
+        const leftButton: HeaderButton = {
+          text: '戻る',
+          onClick: vi.fn(),
+        };
+
+        render(<NurseryHeader title="タイトル" leftButton={leftButton} />);
+
+        expect(
+          screen.getByRole('button', { name: '戻る' })
+        ).toBeInTheDocument();
+      });
+
+      it('テキストボタンがクリックできる', async () => {
+        const user = userEvent.setup();
+        const mockOnClick = vi.fn();
+        const leftButton: HeaderButton = {
+          text: '戻る',
+          onClick: mockOnClick,
+        };
+
+        render(<NurseryHeader title="タイトル" leftButton={leftButton} />);
+
+        const button = screen.getByRole('button', { name: '戻る' });
+        await user.click(button);
+
+        expect(mockOnClick).toHaveBeenCalledTimes(1);
+      });
+
+      it('テキストボタンのvariantが適用される', () => {
+        const leftButton: HeaderButton = {
+          text: '戻る',
+          onClick: vi.fn(),
+          variant: 'outline',
+        };
+
+        render(<NurseryHeader title="タイトル" leftButton={leftButton} />);
+
+        const button = screen.getByRole('button', { name: '戻る' });
+        expect(button).toBeInTheDocument();
+        // variantプロパティが正しく渡され、ボタンが正常にレンダリングされることを確認
+        // Chakra UI v3では内部的にvariantが処理されるため、実用的な検証として
+        // ボタンがクリック可能状態であることを確認
+        expect(button).toBeEnabled();
+      });
+
+      it('variantが指定されない場合はghostがデフォルトになる', () => {
+        const leftButton: HeaderButton = {
+          text: '戻る',
+          onClick: vi.fn(),
+        };
+
+        render(<NurseryHeader title="タイトル" leftButton={leftButton} />);
+
+        const button = screen.getByRole('button', { name: '戻る' });
+        expect(button).toBeInTheDocument();
+        // デフォルトでghostバリアントが適用され、ボタンが正常に動作することを確認
+        expect(button).toBeEnabled();
+      });
+    });
+
+    describe('アイコンボタン', () => {
+      it('アイコンボタンが表示される', () => {
+        const leftButton: HeaderButton = {
+          icon: <IoClose />,
+          onClick: vi.fn(),
+          'aria-label': '閉じる',
+        };
+
+        render(<NurseryHeader title="タイトル" leftButton={leftButton} />);
+
+        expect(
+          screen.getByRole('button', { name: '閉じる' })
+        ).toBeInTheDocument();
+      });
+
+      it('アイコンボタンがクリックできる', async () => {
+        const user = userEvent.setup();
+        const mockOnClick = vi.fn();
+        const leftButton: HeaderButton = {
+          icon: <IoClose />,
+          onClick: mockOnClick,
+          'aria-label': '閉じる',
+        };
+
+        render(<NurseryHeader title="タイトル" leftButton={leftButton} />);
+
+        const button = screen.getByRole('button', { name: '閉じる' });
+        await user.click(button);
+
+        expect(mockOnClick).toHaveBeenCalledTimes(1);
+      });
+
+      it('aria-labelが指定されない場合はデフォルトが使用される', () => {
+        const leftButton: HeaderButton = {
+          icon: <IoClose />,
+          onClick: vi.fn(),
+        };
+
+        render(<NurseryHeader title="タイトル" leftButton={leftButton} />);
+
+        expect(
+          screen.getByRole('button', { name: 'Action button' })
+        ).toBeInTheDocument();
+      });
+
+      it('アイコンとテキストの両方が指定された場合はアイコンボタンが優先される', () => {
+        const leftButton: HeaderButton = {
+          icon: <IoClose />,
+          text: '閉じる（テキスト）',
+          onClick: vi.fn(),
+          'aria-label': '閉じる（アイコン）',
+        };
+
+        render(<NurseryHeader title="タイトル" leftButton={leftButton} />);
+
+        expect(
+          screen.getByRole('button', { name: '閉じる（アイコン）' })
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByRole('button', { name: '閉じる（テキスト）' })
+        ).not.toBeInTheDocument();
+      });
+
+      it('アイコンボタンのvariantが適用される', () => {
+        const leftButton: HeaderButton = {
+          icon: <IoClose />,
+          onClick: vi.fn(),
+          'aria-label': '閉じる',
+          variant: 'solid',
+        };
+
+        render(<NurseryHeader title="タイトル" leftButton={leftButton} />);
+
+        const button = screen.getByRole('button', { name: '閉じる' });
+        expect(button).toBeInTheDocument();
+        // IconButtonにvariantが適用され、ボタンが正常に動作することを確認
+        expect(button).toBeEnabled();
+      });
+
+      it('アイコンボタンでvariantが指定されない場合はghostがデフォルトになる', () => {
+        const leftButton: HeaderButton = {
+          icon: <IoClose />,
+          onClick: vi.fn(),
+          'aria-label': '閉じる',
+        };
+
+        render(<NurseryHeader title="タイトル" leftButton={leftButton} />);
+
+        const button = screen.getByRole('button', { name: '閉じる' });
+        expect(button).toBeInTheDocument();
+        // デフォルトでghostバリアントが適用され、ボタンが正常に動作することを確認
+        expect(button).toBeEnabled();
+      });
+    });
+  });
+
+  describe('右ボタン（rightButton）', () => {
+    describe('テキストボタン', () => {
+      it('テキストボタンが表示される', () => {
+        const rightButton: HeaderButton = {
+          text: '保存',
+          onClick: vi.fn(),
+        };
+
+        render(<NurseryHeader title="タイトル" rightButton={rightButton} />);
+
+        expect(
+          screen.getByRole('button', { name: '保存' })
+        ).toBeInTheDocument();
+      });
+
+      it('テキストボタンがクリックできる', async () => {
+        const user = userEvent.setup();
+        const mockOnClick = vi.fn();
+        const rightButton: HeaderButton = {
+          text: '保存',
+          onClick: mockOnClick,
+        };
+
+        render(<NurseryHeader title="タイトル" rightButton={rightButton} />);
+
+        const button = screen.getByRole('button', { name: '保存' });
+        await user.click(button);
+
+        expect(mockOnClick).toHaveBeenCalledTimes(1);
+      });
+
+      it('右ボタンのvariantが適用される', () => {
+        const rightButton: HeaderButton = {
+          text: '保存',
+          onClick: vi.fn(),
+          variant: 'solid',
+        };
+
+        render(<NurseryHeader title="タイトル" rightButton={rightButton} />);
+
+        const button = screen.getByRole('button', { name: '保存' });
+        expect(button).toBeInTheDocument();
+        // variantが適用され、ボタンが正常に動作することを確認
+        expect(button).toBeEnabled();
+      });
+
+      it('右ボタンでvariantが指定されない場合はghostがデフォルトになる', () => {
+        const rightButton: HeaderButton = {
+          text: '保存',
+          onClick: vi.fn(),
+        };
+
+        render(<NurseryHeader title="タイトル" rightButton={rightButton} />);
+
+        const button = screen.getByRole('button', { name: '保存' });
+        expect(button).toBeInTheDocument();
+        // デフォルトでghostバリアントが適用され、ボタンが正常に動作することを確認
+        expect(button).toBeEnabled();
+      });
+    });
+
+    describe('アイコンボタン', () => {
+      it('アイコンボタンが表示される', () => {
+        const rightButton: HeaderButton = {
+          icon: <IoArrowBack />,
+          onClick: vi.fn(),
+          'aria-label': '進む',
+        };
+
+        render(<NurseryHeader title="タイトル" rightButton={rightButton} />);
+
+        expect(
+          screen.getByRole('button', { name: '進む' })
+        ).toBeInTheDocument();
+      });
+
+      it('アイコンボタンがクリックできる', async () => {
+        const user = userEvent.setup();
+        const mockOnClick = vi.fn();
+        const rightButton: HeaderButton = {
+          icon: <IoArrowBack />,
+          onClick: mockOnClick,
+          'aria-label': '進む',
+        };
+
+        render(<NurseryHeader title="タイトル" rightButton={rightButton} />);
+
+        const button = screen.getByRole('button', { name: '進む' });
+        await user.click(button);
+
+        expect(mockOnClick).toHaveBeenCalledTimes(1);
+      });
+
+      it('右アイコンボタンのvariantが適用される', () => {
+        const rightButton: HeaderButton = {
+          icon: <IoArrowBack />,
+          onClick: vi.fn(),
+          'aria-label': '進む',
+          variant: 'outline',
+        };
+
+        render(<NurseryHeader title="タイトル" rightButton={rightButton} />);
+
+        const button = screen.getByRole('button', { name: '進む' });
+        expect(button).toBeInTheDocument();
+        // IconButtonにvariantが適用され、ボタンが正常に動作することを確認
+        expect(button).toBeEnabled();
+      });
+
+      it('右アイコンボタンでvariantが指定されない場合はghostがデフォルトになる', () => {
+        const rightButton: HeaderButton = {
+          icon: <IoArrowBack />,
+          onClick: vi.fn(),
+          'aria-label': '進む',
+        };
+
+        render(<NurseryHeader title="タイトル" rightButton={rightButton} />);
+
+        const button = screen.getByRole('button', { name: '進む' });
+        expect(button).toBeInTheDocument();
+        // デフォルトでghostバリアントが適用され、ボタンが正常に動作することを確認
+        expect(button).toBeEnabled();
+      });
+    });
+  });
+
+  describe('両方のボタン', () => {
+    it('左右両方のボタンが表示される', () => {
+      const leftButton: HeaderButton = {
+        text: '戻る',
+        onClick: vi.fn(),
+      };
+      const rightButton: HeaderButton = {
+        text: '保存',
+        onClick: vi.fn(),
+      };
+
+      render(
+        <NurseryHeader
+          title="タイトル"
+          leftButton={leftButton}
+          rightButton={rightButton}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: '戻る' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '保存' })).toBeInTheDocument();
+    });
+
+    it('左右のボタンが独立してクリックできる', async () => {
+      const user = userEvent.setup();
+      const mockLeftClick = vi.fn();
+      const mockRightClick = vi.fn();
+      const leftButton: HeaderButton = {
+        text: '戻る',
+        onClick: mockLeftClick,
+      };
+      const rightButton: HeaderButton = {
+        text: '保存',
+        onClick: mockRightClick,
+      };
+
+      render(
+        <NurseryHeader
+          title="タイトル"
+          leftButton={leftButton}
+          rightButton={rightButton}
+        />
+      );
+
+      const leftBtn = screen.getByRole('button', { name: '戻る' });
+      const rightBtn = screen.getByRole('button', { name: '保存' });
+
+      await user.click(leftBtn);
+      expect(mockLeftClick).toHaveBeenCalledTimes(1);
+      expect(mockRightClick).not.toHaveBeenCalled();
+
+      await user.click(rightBtn);
+      expect(mockRightClick).toHaveBeenCalledTimes(1);
+      expect(mockLeftClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('両方のボタンにそれぞれ異なるvariantが適用される', () => {
+      const leftButton: HeaderButton = {
+        text: '戻る',
+        onClick: vi.fn(),
+        variant: 'outline',
+      };
+      const rightButton: HeaderButton = {
+        text: '保存',
+        onClick: vi.fn(),
+        variant: 'solid',
+      };
+
+      render(
+        <NurseryHeader
+          title="タイトル"
+          leftButton={leftButton}
+          rightButton={rightButton}
+        />
+      );
+
+      const leftBtn = screen.getByRole('button', { name: '戻る' });
+      const rightBtn = screen.getByRole('button', { name: '保存' });
+
+      // 両方のボタンにそれぞれ異なるvariantが適用され、正常に動作することを確認
+      expect(leftBtn).toBeEnabled();
+      expect(rightBtn).toBeEnabled();
+    });
+  });
+
+  describe('アクセシビリティ', () => {
+    it('タイトルがheadingロールを持つ', () => {
+      render(<NurseryHeader title="アクセシブルタイトル" />);
+
+      expect(
+        screen.getByRole('heading', { name: 'アクセシブルタイトル' })
+      ).toBeInTheDocument();
+    });
+
+    it('アイコンボタンに適切なaria-labelが設定される', () => {
+      const leftButton: HeaderButton = {
+        icon: <IoClose />,
+        onClick: vi.fn(),
+        'aria-label': 'モーダルを閉じる',
+      };
+
+      render(<NurseryHeader title="タイトル" leftButton={leftButton} />);
+
+      expect(
+        screen.getByRole('button', { name: 'モーダルを閉じる' })
+      ).toBeInTheDocument();
+    });
+
+    it('キーボードナビゲーションが可能', async () => {
+      const user = userEvent.setup();
+      const mockLeftClick = vi.fn();
+      const mockRightClick = vi.fn();
+      const leftButton: HeaderButton = {
+        text: '戻る',
+        onClick: mockLeftClick,
+      };
+      const rightButton: HeaderButton = {
+        text: '保存',
+        onClick: mockRightClick,
+      };
+
+      render(
+        <NurseryHeader
+          title="タイトル"
+          leftButton={leftButton}
+          rightButton={rightButton}
+        />
+      );
+
+      // Tabキーで左ボタンにフォーカス
+      await user.tab();
+      const leftBtn = screen.getByRole('button', { name: '戻る' });
+      expect(leftBtn).toHaveFocus();
+
+      // Enterキーでクリック
+      await user.keyboard('{Enter}');
+      expect(mockLeftClick).toHaveBeenCalledTimes(1);
+
+      // Tabキーで右ボタンにフォーカス
+      await user.tab();
+      const rightBtn = screen.getByRole('button', { name: '保存' });
+      expect(rightBtn).toHaveFocus();
+
+      // Spaceキーでクリック
+      await user.keyboard(' ');
+      expect(mockRightClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('空のタイトルが指定されても表示される', () => {
+      render(<NurseryHeader title="" />);
+
+      const heading = screen.getByRole('heading');
+      expect(heading).toBeInTheDocument();
+      expect(heading).toHaveTextContent('');
+    });
+
+    it('長いタイトルが指定されても正しく表示される', () => {
+      const longTitle = 'とても長いタイトルです'.repeat(10);
+      render(<NurseryHeader title={longTitle} />);
+
+      expect(
+        screen.getByRole('heading', { name: longTitle })
+      ).toBeInTheDocument();
+    });
+
+    it('onClickハンドラーがundefinedでもエラーにならない', () => {
+      // TypeScript的には起こりえないが、ランタイムでの安全性を確認
+      const leftButton = {
+        text: '戻る',
+        onClick: undefined as any,
+      };
+
+      expect(() => {
+        render(<NurseryHeader title="タイトル" leftButton={leftButton} />);
+      }).not.toThrow();
+    });
+  });
+
+  describe('パフォーマンス', () => {
+    it('同じpropsで再レンダリングされても余分な処理が発生しない', () => {
+      const mockOnClick = vi.fn();
+      const leftButton: HeaderButton = {
+        text: '戻る',
+        onClick: mockOnClick,
+      };
+
+      const { rerender } = render(
+        <NurseryHeader title="タイトル" leftButton={leftButton} />
+      );
+
+      // 同じpropsで再レンダリング
+      rerender(<NurseryHeader title="タイトル" leftButton={leftButton} />);
+
+      // ボタンが正常に動作することを確認
+      const button = screen.getByRole('button', { name: '戻る' });
+      expect(button).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/NurseryHeader.tsx
+++ b/src/components/NurseryHeader.tsx
@@ -2,7 +2,7 @@
  * 共通ヘッダーコンポーネント（Chakra UI v3対応）
  */
 
-import { Button, Heading, HStack, IconButton } from '@chakra-ui/react';
+import { Box, Button, Heading, HStack, IconButton } from '@chakra-ui/react';
 import type { HeaderButton, HeaderVariant } from '../types/header';
 
 interface NurseryHeaderProps {
@@ -39,7 +39,7 @@ export const NurseryHeader = ({
             onClick={leftButton.onClick}
             variant={leftButton.variant || 'ghost'}
             aria-label={leftButton['aria-label'] || 'Action button'}
-            size={{ base: 'xs', md: 'md' }}
+            size={{ base: 'sm', md: 'md' }}
             borderRadius="full"
             _hover={{ bg: 'gray.100' }}
           >
@@ -56,7 +56,7 @@ export const NurseryHeader = ({
           </Button>
         )
       ) : (
-        <div style={{ width: '40px' }} /> // スペーサー
+        <Box w="40px" />
       )}
 
       <Heading
@@ -91,7 +91,7 @@ export const NurseryHeader = ({
           </Button>
         )
       ) : (
-        <div style={{ width: '40px' }} /> // スペーサー
+        <Box w="40px" />
       )}
     </HStack>
   );

--- a/src/components/NurseryHeader.tsx
+++ b/src/components/NurseryHeader.tsx
@@ -1,24 +1,64 @@
 /**
- * 保育園詳細ページヘッダーコンポーネント
+ * 共通ヘッダーコンポーネント（Chakra UI v3対応）
  */
 
-import { Button, Heading, Spacer } from '@chakra-ui/react';
+import { Button, Heading, HStack, IconButton } from '@chakra-ui/react';
+import type { HeaderButton, HeaderVariant } from '../types/header';
 
 interface NurseryHeaderProps {
-  onBack: () => void;
+  title: string;
+  leftButton?: HeaderButton;
+  rightButton?: HeaderButton;
+  variant?: HeaderVariant;
 }
 
-export const NurseryHeader = ({ onBack }: NurseryHeaderProps) => {
-  return (
-    <>
-      <Button
-        variant="ghost"
-        onClick={onBack}
-        size={{ base: 'sm', md: 'md' }}
-        px={0}
+export const NurseryHeader = ({
+  title,
+  leftButton,
+  rightButton,
+  variant = 'with-buttons',
+}: NurseryHeaderProps) => {
+  if (variant === 'centered') {
+    return (
+      <Heading
+        as="h1"
+        size={{ base: 'md', md: 'lg' }}
+        color="teal.600"
+        textAlign="center"
       >
-        ← 戻る
-      </Button>
+        {title}
+      </Heading>
+    );
+  }
+
+  return (
+    <HStack justify="space-between" align="center" w="full">
+      {leftButton ? (
+        leftButton.icon ? (
+          <IconButton
+            onClick={leftButton.onClick}
+            variant={leftButton.variant || 'ghost'}
+            aria-label={leftButton['aria-label'] || 'Action button'}
+            size={{ base: 'xs', md: 'md' }}
+            borderRadius="full"
+            _hover={{ bg: 'gray.100' }}
+          >
+            {leftButton.icon}
+          </IconButton>
+        ) : (
+          <Button
+            variant={leftButton.variant || 'ghost'}
+            onClick={leftButton.onClick}
+            size={{ base: 'sm', md: 'md' }}
+            px={0}
+          >
+            {leftButton.text}
+          </Button>
+        )
+      ) : (
+        <div style={{ width: '40px' }} /> // スペーサー
+      )}
+
       <Heading
         as="h1"
         size={{ base: 'md', md: 'lg' }}
@@ -26,9 +66,33 @@ export const NurseryHeader = ({ onBack }: NurseryHeaderProps) => {
         flex={1}
         textAlign="center"
       >
-        保育園詳細
+        {title}
       </Heading>
-      <Spacer />
-    </>
+
+      {rightButton ? (
+        rightButton.icon ? (
+          <IconButton
+            onClick={rightButton.onClick}
+            variant={rightButton.variant || 'ghost'}
+            aria-label={rightButton['aria-label'] || 'Action button'}
+            size={{ base: 'sm', md: 'md' }}
+            borderRadius="full"
+            _hover={{ bg: 'gray.100' }}
+          >
+            {rightButton.icon}
+          </IconButton>
+        ) : (
+          <Button
+            variant={rightButton.variant || 'ghost'}
+            onClick={rightButton.onClick}
+            size={{ base: 'sm', md: 'md' }}
+          >
+            {rightButton.text}
+          </Button>
+        )
+      ) : (
+        <div style={{ width: '40px' }} /> // スペーサー
+      )}
+    </HStack>
   );
 };

--- a/src/types/header.ts
+++ b/src/types/header.ts
@@ -1,0 +1,15 @@
+/**
+ * ヘッダー関連の型定義
+ */
+
+import React from 'react';
+
+export interface HeaderButton {
+  icon?: React.ReactElement;
+  text?: string;
+  onClick: () => void;
+  variant?: 'ghost' | 'solid' | 'outline';
+  'aria-label'?: string;
+}
+
+export type HeaderVariant = 'centered' | 'with-buttons';


### PR DESCRIPTION
## Summary
- ヘッダー実装の重複を解消し、NurseryHeaderを共通コンポーネントとして拡張
- Chakra UI v3の最新パターンを使用してvariantとボタン設定を支援
- t-wada式TDDに準拠した包括的テストスイート（36テストケース）を追加

## Test plan
- [x] 全36テストケースがパス
- [x] ESLint・TypeScriptのエラーなし
- [x] 各ページでヘッダーが正常に表示される
- [x] ボタンのクリック動作が正常
- [x] レスポンシブデザインが維持される

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ヘッダーコンポーネントがさらに柔軟にカスタマイズ可能になり、タイトル、左右のボタン、レイアウトバリエーションを細かく設定できるようになりました。
  * ボタンはアイコンまたはテキストで指定可能となり、アクセシビリティ対応も強化されました。

* **リファクタリング**
  * 各ページのヘッダー設定が統一され、`Layout`コンポーネントのプロパティで簡潔に制御できるようになりました。
  * ヘッダーの内部実装が共通化され、コードの冗長性が削減されました。

* **テスト**
  * ヘッダーコンポーネントの包括的なテストが追加され、動作の正確性とアクセシビリティが保証されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->