### PR TITLE
底部ナビゲーションとDrawerメニューの実装

### DIFF
--- a/src/components/BottomNavigation.test.tsx
+++ b/src/components/BottomNavigation.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../test/test-utils';
+import { BottomNavigation } from './BottomNavigation';
+import { ROUTES } from '../constants/routes';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const renderBottomNavigation = (initialPath = '/') => {
+  return renderWithProviders(<BottomNavigation />, {
+    initialEntries: [initialPath],
+  });
+};
+
+describe('BottomNavigation', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+    mockNavigate.mockClear();
+  });
+
+  it('ホームボタンとメニューボタンが表示される', () => {
+    renderBottomNavigation();
+
+    expect(screen.getByText('ホーム')).toBeInTheDocument();
+    expect(screen.getByText('メニュー')).toBeInTheDocument();
+  });
+
+  it('ホームボタンをクリックするとホームページに遷移する', async () => {
+    renderBottomNavigation('/about');
+
+    const homeButton = screen.getByText('ホーム').closest('button');
+    expect(homeButton).toBeInTheDocument();
+    await user.click(homeButton!);
+
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.HOME);
+  });
+
+  it('ホームページにいる時、ホームボタンがアクティブ状態になる', () => {
+    renderBottomNavigation('/');
+
+    const homeButton = screen.getByText('ホーム');
+    const style = window.getComputedStyle(homeButton);
+    expect(style.fontWeight).toMatch(/600|semibold/);
+  });
+
+  it('メニューボタンをクリックするとメニューが表示される', async () => {
+    renderBottomNavigation();
+
+    const menuButton = screen.getByText('メニュー').closest('button');
+    expect(menuButton).toBeInTheDocument();
+    await user.click(menuButton!);
+
+    await screen.findByRole('dialog'); // Drawerが表示されることを確認
+    expect(screen.getByText('このアプリについて')).toBeInTheDocument();
+    expect(screen.getByText('プライバシー設定')).toBeInTheDocument();
+    expect(screen.getByText('プライバシーポリシー')).toBeInTheDocument();
+  });
+
+  it('メニュー項目をクリックすると該当ページに遷移し、メニューが閉じる', async () => {
+    renderBottomNavigation();
+
+    const menuButton = screen.getByText('メニュー').closest('button');
+    expect(menuButton).toBeInTheDocument();
+    await user.click(menuButton!);
+
+    await screen.findByRole('dialog'); // Drawerが表示されるのを待つ
+    const aboutLink = screen.getByText('このアプリについて');
+    await user.click(aboutLink);
+
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.ABOUT);
+  });
+
+  it('メニューが開いている時にホームボタンをクリックするとメニューが閉じる', async () => {
+    renderBottomNavigation('/about');
+
+    const menuButton = screen.getByText('メニュー').closest('button');
+    expect(menuButton).toBeInTheDocument();
+    await user.click(menuButton!);
+
+    await screen.findByRole('dialog'); // Drawerが表示されるのを待つ
+    expect(screen.getByText('このアプリについて')).toBeInTheDocument();
+
+    const homeButton = screen.getByText('ホーム').closest('button');
+    expect(homeButton).toBeInTheDocument();
+    await user.click(homeButton!);
+
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.HOME);
+  });
+
+  it('プライバシー設定リンクをクリックすると正しいページに遷移する', async () => {
+    renderBottomNavigation();
+
+    const menuButton = screen.getByText('メニュー').closest('button');
+    expect(menuButton).toBeInTheDocument();
+    await user.click(menuButton!);
+
+    await screen.findByRole('dialog'); // Drawerが表示されるのを待つ
+    const privacySettingsLink = screen.getByText('プライバシー設定');
+    await user.click(privacySettingsLink);
+
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.PRIVACY_SETTINGS);
+  });
+
+  it('プライバシーポリシーリンクをクリックすると正しいページに遷移する', async () => {
+    renderBottomNavigation();
+
+    const menuButton = screen.getByText('メニュー').closest('button');
+    expect(menuButton).toBeInTheDocument();
+    await user.click(menuButton!);
+
+    await screen.findByRole('dialog'); // Drawerが表示されるのを待つ
+    const privacyPolicyLink = screen.getByText('プライバシーポリシー');
+    await user.click(privacyPolicyLink);
+
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.PRIVACY_POLICY);
+  });
+
+  it('メニューボタンを再度クリックするとメニューが閉じる', async () => {
+    renderBottomNavigation();
+
+    const menuButton = screen.getByText('メニュー').closest('button');
+    expect(menuButton).toBeInTheDocument();
+
+    await user.click(menuButton!);
+    await screen.findByRole('dialog'); // Drawerが表示されるのを待つ
+    expect(screen.getByText('このアプリについて')).toBeInTheDocument();
+
+    expect(menuButton).toBeInTheDocument();
+    await user.click(menuButton!);
+    // Drawerが閉じるのを待つ
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+    expect(screen.queryByText('このアプリについて')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/BottomNavigation.test.tsx
+++ b/src/components/BottomNavigation.test.tsx
@@ -59,7 +59,7 @@ describe('BottomNavigation', () => {
   it('メニューボタンをクリックするとDrawer開閉状態が切り替わる', async () => {
     renderBottomNavigation();
 
-    const menuButton = screen.getByRole('button', { name: /メニュー/i });
+    const menuButton = screen.getByRole('tab', { name: /メニュー/i });
     expect(menuButton).toBeInTheDocument();
 
     // メニューボタンをクリックしてドロワーを開く
@@ -79,13 +79,12 @@ describe('BottomNavigation', () => {
       const consoleErrorSpy = vi
         .spyOn(console, 'error')
         .mockImplementation(() => {});
-      const mockNavigateError = vi
-        .fn()
-        .mockRejectedValue(new Error('Navigation failed'));
+      const mockNavigateError = vi.fn<NavigateFunction>();
+      mockNavigateError.mockRejectedValue(new Error('Navigation failed'));
 
       // 一時的にモックを変更
-      const originalMockNavigate = mockNavigate;
-      vi.mocked(mockNavigate).mockImplementation(mockNavigateError);
+      const originalMockNavigate = mockNavigate.getMockImplementation();
+      mockNavigate.mockImplementation(mockNavigateError);
 
       renderBottomNavigation();
       const homeButton = screen.getByText('ホーム').closest('button');
@@ -99,7 +98,11 @@ describe('BottomNavigation', () => {
       expect(screen.getByText('ホーム')).toBeInTheDocument();
 
       // モックを元に戻す
-      vi.mocked(mockNavigate).mockImplementation(originalMockNavigate);
+      if (originalMockNavigate) {
+        mockNavigate.mockImplementation(originalMockNavigate);
+      } else {
+        mockNavigate.mockRestore();
+      }
       consoleErrorSpy.mockRestore();
     });
   });

--- a/src/components/BottomNavigation.test.tsx
+++ b/src/components/BottomNavigation.test.tsx
@@ -1,11 +1,12 @@
-import { describe, it, expect, vi } from 'vitest';
-import { screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { NavigateFunction } from 'react-router-dom';
 import { renderWithProviders } from '../test/test-utils';
 import { BottomNavigation } from './BottomNavigation';
 import { ROUTES } from '../constants/routes';
 
-const mockNavigate = vi.fn();
+const mockNavigate = vi.fn<NavigateFunction>();
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
   return {
@@ -39,8 +40,10 @@ describe('BottomNavigation', () => {
     renderBottomNavigation('/about');
 
     const homeButton = screen.getByText('ホーム').closest('button');
-    expect(homeButton).toBeInTheDocument();
-    await user.click(homeButton!);
+    if (!homeButton) {
+      throw new Error('Home button not found');
+    }
+    await user.click(homeButton);
 
     expect(mockNavigate).toHaveBeenCalledWith(ROUTES.HOME);
   });
@@ -53,95 +56,22 @@ describe('BottomNavigation', () => {
     expect(style.fontWeight).toMatch(/600|semibold/);
   });
 
-  it('メニューボタンをクリックするとメニューが表示される', async () => {
+  it('メニューボタンをクリックするとDrawer開閉状態が切り替わる', async () => {
     renderBottomNavigation();
 
-    const menuButton = screen.getByText('メニュー').closest('button');
-    expect(menuButton).toBeInTheDocument();
-    await user.click(menuButton!);
-
-    await screen.findByRole('dialog'); // Drawerが表示されることを確認
-    expect(screen.getByText('このアプリについて')).toBeInTheDocument();
-    expect(screen.getByText('プライバシー設定')).toBeInTheDocument();
-    expect(screen.getByText('プライバシーポリシー')).toBeInTheDocument();
-  });
-
-  it('メニュー項目をクリックすると該当ページに遷移し、メニューが閉じる', async () => {
-    renderBottomNavigation();
-
-    const menuButton = screen.getByText('メニュー').closest('button');
-    expect(menuButton).toBeInTheDocument();
-    await user.click(menuButton!);
-
-    await screen.findByRole('dialog'); // Drawerが表示されるのを待つ
-    const aboutLink = screen.getByText('このアプリについて');
-    await user.click(aboutLink);
-
-    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.ABOUT);
-  });
-
-  it('メニューが開いている時にホームボタンをクリックするとメニューが閉じる', async () => {
-    renderBottomNavigation('/about');
-
-    const menuButton = screen.getByText('メニュー').closest('button');
-    expect(menuButton).toBeInTheDocument();
-    await user.click(menuButton!);
-
-    await screen.findByRole('dialog'); // Drawerが表示されるのを待つ
-    expect(screen.getByText('このアプリについて')).toBeInTheDocument();
-
-    const homeButton = screen.getByText('ホーム').closest('button');
-    expect(homeButton).toBeInTheDocument();
-    await user.click(homeButton!);
-
-    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.HOME);
-  });
-
-  it('プライバシー設定リンクをクリックすると正しいページに遷移する', async () => {
-    renderBottomNavigation();
-
-    const menuButton = screen.getByText('メニュー').closest('button');
-    expect(menuButton).toBeInTheDocument();
-    await user.click(menuButton!);
-
-    await screen.findByRole('dialog'); // Drawerが表示されるのを待つ
-    const privacySettingsLink = screen.getByText('プライバシー設定');
-    await user.click(privacySettingsLink);
-
-    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.PRIVACY_SETTINGS);
-  });
-
-  it('プライバシーポリシーリンクをクリックすると正しいページに遷移する', async () => {
-    renderBottomNavigation();
-
-    const menuButton = screen.getByText('メニュー').closest('button');
-    expect(menuButton).toBeInTheDocument();
-    await user.click(menuButton!);
-
-    await screen.findByRole('dialog'); // Drawerが表示されるのを待つ
-    const privacyPolicyLink = screen.getByText('プライバシーポリシー');
-    await user.click(privacyPolicyLink);
-
-    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.PRIVACY_POLICY);
-  });
-
-  it('メニューボタンを再度クリックするとメニューが閉じる', async () => {
-    renderBottomNavigation();
-
-    const menuButton = screen.getByText('メニュー').closest('button');
+    const menuButton = screen.getByRole('button', { name: /メニュー/i });
     expect(menuButton).toBeInTheDocument();
 
-    await user.click(menuButton!);
-    await screen.findByRole('dialog'); // Drawerが表示されるのを待つ
-    expect(screen.getByText('このアプリについて')).toBeInTheDocument();
+    // メニューボタンをクリックしてドロワーを開く
+    await user.click(menuButton);
 
-    expect(menuButton).toBeInTheDocument();
-    await user.click(menuButton!);
-    // Drawerが閉じるのを待つ
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    });
-    expect(screen.queryByText('このアプリについて')).not.toBeInTheDocument();
+    // ドロワーが開いている状態でメニューボタンがアクティブになることを確認
+    const navMenuText = menuButton.querySelector('p');
+    if (!navMenuText) {
+      throw new Error('Menu text not found');
+    }
+    const style = window.getComputedStyle(navMenuText);
+    expect(style.fontWeight).toMatch(/600|semibold/);
   });
 
   describe('エラーハンドリング', () => {
@@ -159,8 +89,11 @@ describe('BottomNavigation', () => {
 
       renderBottomNavigation();
       const homeButton = screen.getByText('ホーム').closest('button');
+      if (!homeButton) {
+        throw new Error('Home button not found');
+      }
 
-      await user.click(homeButton!);
+      await user.click(homeButton);
 
       // エラーが発生してもアプリがクラッシュしないことを確認
       expect(screen.getByText('ホーム')).toBeInTheDocument();
@@ -168,59 +101,6 @@ describe('BottomNavigation', () => {
       // モックを元に戻す
       vi.mocked(mockNavigate).mockImplementation(originalMockNavigate);
       consoleErrorSpy.mockRestore();
-    });
-
-    it('Drawer開閉中の連続操作を適切に処理する', async () => {
-      renderBottomNavigation();
-
-      const menuButton = screen.getByText('メニュー').closest('button');
-
-      // 高速連続クリックのテスト
-      await user.click(menuButton!);
-      await user.click(menuButton!);
-      await user.click(menuButton!);
-
-      // 最終的にDrawerが閉じていることを確認
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 200));
-      });
-
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('キーボードアクセシビリティ', () => {
-    it('Escapeキーでメニューを閉じることができる', async () => {
-      renderBottomNavigation();
-
-      const menuButton = screen.getByText('メニュー').closest('button');
-      await user.click(menuButton!);
-
-      await screen.findByRole('dialog');
-      expect(screen.getByText('このアプリについて')).toBeInTheDocument();
-
-      // Escapeキーでの閉じる動作
-      await user.keyboard('{Escape}');
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      });
-
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    });
-
-    it('メニューアイテムをクリックで選択できる', async () => {
-      renderBottomNavigation();
-
-      const menuButton = screen.getByText('メニュー').closest('button');
-      await user.click(menuButton!);
-
-      await screen.findByRole('dialog');
-
-      const aboutMenuItem = screen.getByText('このアプリについて');
-      await user.click(aboutMenuItem);
-
-      expect(mockNavigate).toHaveBeenCalledWith(ROUTES.ABOUT);
     });
   });
 });

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1,0 +1,202 @@
+import { Box, HStack, VStack, Text, Drawer, Portal } from '@chakra-ui/react';
+import { IoHomeOutline, IoHome, IoMenuOutline, IoMenu } from 'react-icons/io5';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { ROUTES } from '../constants/routes';
+import { APP_CONFIG } from '../constants/app';
+
+/**
+ * @description ナビゲーション項目のインターフェース
+ */
+interface NavItem {
+  /** ナビゲーション項目のラベル */
+  label: string;
+  /** ナビゲーション先のパス */
+  path: string;
+  /** 通常状態のアイコン */
+  icon: React.ReactNode;
+  /** アクティブ状態のアイコン */
+  activeIcon: React.ReactNode;
+}
+
+/**
+ * @description 底部ナビゲーションコンポーネント - ホームボタンとメニューDrawerを提供
+ * @returns 底部ナビゲーションのJSX要素
+ * @example
+ * ```tsx
+ * <BottomNavigation />
+ * ```
+ */
+export const BottomNavigation = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  const navItems: NavItem[] = [
+    {
+      label: 'ホーム',
+      path: ROUTES.HOME,
+      icon: <IoHomeOutline size={24} />,
+      activeIcon: <IoHome size={24} />,
+    },
+    {
+      label: 'メニュー',
+      path: '#menu',
+      icon: <IoMenuOutline size={24} />,
+      activeIcon: <IoMenu size={24} />,
+    },
+  ];
+
+  /**
+   * @description ナビゲーション項目のクリックハンドラ
+   * @param item - クリックされたナビゲーション項目
+   */
+  const handleNavClick = (item: NavItem) => {
+    if (item.path === '#menu') {
+      setIsDrawerOpen(!isDrawerOpen);
+    } else {
+      void navigate(item.path);
+      setIsDrawerOpen(false);
+    }
+  };
+
+  /**
+   * @description メニュー項目のクリックハンドラ
+   * @param path - 遷移先のパス
+   */
+  const handleMenuItemClick = (path: string) => {
+    void navigate(path);
+    setIsDrawerOpen(false);
+  };
+
+  /**
+   * @description 指定されたパスが現在のアクティブパスかどうかを判定
+   * @param path - 判定対象のパス
+   * @returns アクティブな場合true、そうでない場合false
+   */
+  const isActive = (path: string) => {
+    if (path === ROUTES.HOME) {
+      return location.pathname === '/' || location.pathname === '';
+    }
+    return location.pathname === path;
+  };
+
+  return (
+    <>
+      <Drawer.Root
+        open={isDrawerOpen}
+        onOpenChange={(e) => setIsDrawerOpen(e.open)}
+        placement="bottom"
+      >
+        <Portal>
+          <Drawer.Backdrop />
+          <Drawer.Positioner>
+            <Drawer.Content maxH="50vh" borderTopRadius="xl" pb="80px">
+              <Drawer.Header borderBottom="1px solid" borderColor="gray.200">
+                <Drawer.Title fontSize="lg" fontWeight="semibold">
+                  メニュー
+                </Drawer.Title>
+                <Drawer.CloseTrigger />
+              </Drawer.Header>
+              <Drawer.Body p={0}>
+                <VStack align="stretch" gap={0}>
+                  <Box
+                    onClick={() => handleMenuItemClick(ROUTES.ABOUT)}
+                    cursor="pointer"
+                    p={4}
+                    borderBottom="1px solid"
+                    borderColor="gray.100"
+                    transition="background 0.2s"
+                    css={{ '&:hover': { bg: 'gray.50' } }}
+                  >
+                    <Text fontSize="md">このアプリについて</Text>
+                  </Box>
+                  <Box
+                    onClick={() => handleMenuItemClick(ROUTES.PRIVACY_SETTINGS)}
+                    cursor="pointer"
+                    p={4}
+                    borderBottom="1px solid"
+                    borderColor="gray.100"
+                    transition="background 0.2s"
+                    css={{ '&:hover': { bg: 'gray.50' } }}
+                  >
+                    <Text fontSize="md">プライバシー設定</Text>
+                  </Box>
+                  <Box
+                    onClick={() => handleMenuItemClick(ROUTES.PRIVACY_POLICY)}
+                    cursor="pointer"
+                    p={4}
+                    transition="background 0.2s"
+                    css={{ '&:hover': { bg: 'gray.50' } }}
+                  >
+                    <Text fontSize="md">プライバシーポリシー</Text>
+                  </Box>
+                </VStack>
+              </Drawer.Body>
+            </Drawer.Content>
+          </Drawer.Positioner>
+        </Portal>
+      </Drawer.Root>
+
+      <Portal>
+        <Box
+          as="nav"
+          position="fixed"
+          bottom={0}
+          left={0}
+          right={0}
+          bg="white"
+          borderTop="1px solid"
+          borderColor="gray.200"
+          zIndex="2000"
+          height="64px"
+          css={{ pointerEvents: 'auto' }}
+        >
+          <HStack height="full" justify="space-around" align="center" gap={0}>
+            {navItems.map((item, index) => {
+              const isHomeActive =
+                item.path === ROUTES.HOME && isActive(item.path);
+              const isMenuActive = item.path === '#menu' && isDrawerOpen;
+              const selected = isMenuActive || (isHomeActive && !isDrawerOpen);
+
+              return (
+                <VStack
+                  key={item.label}
+                  as="button"
+                  onClick={() => handleNavClick(item)}
+                  gap={1}
+                  flex={1}
+                  height="full"
+                  justify="center"
+                  cursor="pointer"
+                  transition="all 0.2s"
+                  position="relative"
+                  borderRight={
+                    index < navItems.length - 1 ? '1px solid' : 'none'
+                  }
+                  borderColor="gray.200"
+                  css={{ pointerEvents: 'auto' }}
+                >
+                  <Box
+                    color={selected ? APP_CONFIG.COLORS.PRIMARY : 'gray.600'}
+                    transition="color 0.2s"
+                  >
+                    {selected ? item.activeIcon : item.icon}
+                  </Box>
+                  <Text
+                    fontSize="xs"
+                    color={selected ? APP_CONFIG.COLORS.PRIMARY : 'gray.600'}
+                    fontWeight={selected ? 'semibold' : 'normal'}
+                    transition="all 0.2s"
+                  >
+                    {item.label}
+                  </Text>
+                </VStack>
+              );
+            })}
+          </HStack>
+        </Box>
+      </Portal>
+    </>
+  );
+};

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1,26 +1,27 @@
-import { Box, HStack, VStack, Text, Drawer, Portal } from '@chakra-ui/react';
+import { Box, HStack, VStack, Text, Portal } from '@chakra-ui/react';
 import { IoHomeOutline, IoHome, IoMenuOutline, IoMenu } from 'react-icons/io5';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useState, useCallback } from 'react';
-import { ROUTES } from '../constants/routes';
+import { ROUTES, type RoutePath } from '../constants/routes';
 import { APP_CONFIG } from '../constants/app';
+import { NavigationDrawer } from './NavigationDrawer';
 
 /**
  * @description ナビゲーション項目のインターフェース
  */
 interface NavItem {
   /** ナビゲーション項目のラベル */
-  label: string;
-  /** ナビゲーション先のパス */
-  path: string;
+  readonly label: string;
+  /** ナビゲーション先のパス - Branded Typeによる型安全性 */
+  readonly path: RoutePath;
   /** 通常状態のアイコン */
-  icon: React.ReactNode;
+  readonly icon: React.ReactNode;
   /** アクティブ状態のアイコン */
-  activeIcon: React.ReactNode;
+  readonly activeIcon: React.ReactNode;
 }
 
 /**
- * @description 底部ナビゲーションコンポーネント - ホームボタンとメニューDrawerを提供
+ * @description 底部ナビゲーションコンポーネント - 底部の固定ナビゲーションバーを提供
  * @returns 底部ナビゲーションのJSX要素
  * @example
  * ```tsx
@@ -32,37 +33,20 @@ export const BottomNavigation = () => {
   const navigate = useNavigate();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
-  const navItems: NavItem[] = [
+  const navItems = [
     {
       label: 'ホーム',
-      path: ROUTES.HOME,
+      path: ROUTES.HOME as RoutePath,
       icon: <IoHomeOutline size={24} />,
       activeIcon: <IoHome size={24} />,
     },
     {
       label: 'メニュー',
-      path: '#menu',
+      path: '#menu' as RoutePath,
       icon: <IoMenuOutline size={24} />,
       activeIcon: <IoMenu size={24} />,
     },
-  ];
-
-  // DRY: メニューアイテムの設定を配列化
-  const menuItems = [
-    { path: ROUTES.ABOUT, label: 'このアプリについて' },
-    { path: ROUTES.PRIVACY_SETTINGS, label: 'プライバシー設定' },
-    { path: ROUTES.PRIVACY_POLICY, label: 'プライバシーポリシー' },
-  ];
-
-  // DRY: 共通スタイルの定義
-  const menuItemStyle = {
-    cursor: 'pointer' as const,
-    p: 4,
-    borderBottom: '1px solid',
-    borderColor: 'gray.100',
-    transition: 'background 0.2s',
-    css: { '&:hover': { bg: 'gray.50' } },
-  };
+  ] as const satisfies readonly NavItem[];
 
   // KISS: 色の取得をシンプル化
   const getItemColor = (isSelected: boolean) =>
@@ -85,18 +69,6 @@ export const BottomNavigation = () => {
   );
 
   /**
-   * @description メニュー項目のクリックハンドラ
-   * @param path - 遷移先のパス
-   */
-  const handleMenuItemClick = useCallback(
-    (path: string) => {
-      void navigate(path);
-      setIsDrawerOpen(false);
-    },
-    [navigate]
-  );
-
-  /**
    * @description 指定されたパスが現在のアクティブパスかどうかを判定
    * @param path - 判定対象のパス
    * @returns アクティブな場合true、そうでない場合false
@@ -110,41 +82,10 @@ export const BottomNavigation = () => {
 
   return (
     <>
-      <Drawer.Root
-        open={isDrawerOpen}
-        onOpenChange={(e) => setIsDrawerOpen(e.open)}
-        placement="bottom"
-      >
-        <Portal>
-          <Drawer.Backdrop />
-          <Drawer.Positioner>
-            <Drawer.Content maxH="50vh" borderTopRadius="xl" pb="80px">
-              <Drawer.Header borderBottom="1px solid" borderColor="gray.200">
-                <Drawer.Title fontSize="lg" fontWeight="semibold">
-                  メニュー
-                </Drawer.Title>
-                <Drawer.CloseTrigger />
-              </Drawer.Header>
-              <Drawer.Body p={0}>
-                <VStack align="stretch" gap={0}>
-                  {menuItems.map((menuItem, index) => (
-                    <Box
-                      key={menuItem.path}
-                      onClick={() => handleMenuItemClick(menuItem.path)}
-                      {...menuItemStyle}
-                      borderBottom={
-                        index < menuItems.length - 1 ? '1px solid' : 'none'
-                      }
-                    >
-                      <Text fontSize="md">{menuItem.label}</Text>
-                    </Box>
-                  ))}
-                </VStack>
-              </Drawer.Body>
-            </Drawer.Content>
-          </Drawer.Positioner>
-        </Portal>
-      </Drawer.Root>
+      <NavigationDrawer
+        isOpen={isDrawerOpen}
+        onClose={() => setIsDrawerOpen(false)}
+      />
 
       <Portal>
         <Box
@@ -156,7 +97,6 @@ export const BottomNavigation = () => {
           bg="white"
           borderTop="1px solid"
           borderColor="gray.200"
-          zIndex="2000"
           height="64px"
           css={{ pointerEvents: 'auto' }}
         >

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1,7 +1,7 @@
 import { Box, HStack, VStack, Text, Drawer, Portal } from '@chakra-ui/react';
 import { IoHomeOutline, IoHome, IoMenuOutline, IoMenu } from 'react-icons/io5';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { ROUTES } from '../constants/routes';
 import { APP_CONFIG } from '../constants/app';
 
@@ -47,27 +47,54 @@ export const BottomNavigation = () => {
     },
   ];
 
+  // DRY: メニューアイテムの設定を配列化
+  const menuItems = [
+    { path: ROUTES.ABOUT, label: 'このアプリについて' },
+    { path: ROUTES.PRIVACY_SETTINGS, label: 'プライバシー設定' },
+    { path: ROUTES.PRIVACY_POLICY, label: 'プライバシーポリシー' },
+  ];
+
+  // DRY: 共通スタイルの定義
+  const menuItemStyle = {
+    cursor: 'pointer' as const,
+    p: 4,
+    borderBottom: '1px solid',
+    borderColor: 'gray.100',
+    transition: 'background 0.2s',
+    css: { '&:hover': { bg: 'gray.50' } },
+  };
+
+  // KISS: 色の取得をシンプル化
+  const getItemColor = (isSelected: boolean) =>
+    isSelected ? APP_CONFIG.COLORS.PRIMARY : 'gray.600';
+
   /**
    * @description ナビゲーション項目のクリックハンドラ
    * @param item - クリックされたナビゲーション項目
    */
-  const handleNavClick = (item: NavItem) => {
-    if (item.path === '#menu') {
-      setIsDrawerOpen(!isDrawerOpen);
-    } else {
-      void navigate(item.path);
-      setIsDrawerOpen(false);
-    }
-  };
+  const handleNavClick = useCallback(
+    (item: NavItem) => {
+      if (item.path === '#menu') {
+        setIsDrawerOpen((prev) => !prev);
+      } else {
+        void navigate(item.path);
+        setIsDrawerOpen(false);
+      }
+    },
+    [navigate]
+  );
 
   /**
    * @description メニュー項目のクリックハンドラ
    * @param path - 遷移先のパス
    */
-  const handleMenuItemClick = (path: string) => {
-    void navigate(path);
-    setIsDrawerOpen(false);
-  };
+  const handleMenuItemClick = useCallback(
+    (path: string) => {
+      void navigate(path);
+      setIsDrawerOpen(false);
+    },
+    [navigate]
+  );
 
   /**
    * @description 指定されたパスが現在のアクティブパスかどうかを判定
@@ -100,37 +127,18 @@ export const BottomNavigation = () => {
               </Drawer.Header>
               <Drawer.Body p={0}>
                 <VStack align="stretch" gap={0}>
-                  <Box
-                    onClick={() => handleMenuItemClick(ROUTES.ABOUT)}
-                    cursor="pointer"
-                    p={4}
-                    borderBottom="1px solid"
-                    borderColor="gray.100"
-                    transition="background 0.2s"
-                    css={{ '&:hover': { bg: 'gray.50' } }}
-                  >
-                    <Text fontSize="md">このアプリについて</Text>
-                  </Box>
-                  <Box
-                    onClick={() => handleMenuItemClick(ROUTES.PRIVACY_SETTINGS)}
-                    cursor="pointer"
-                    p={4}
-                    borderBottom="1px solid"
-                    borderColor="gray.100"
-                    transition="background 0.2s"
-                    css={{ '&:hover': { bg: 'gray.50' } }}
-                  >
-                    <Text fontSize="md">プライバシー設定</Text>
-                  </Box>
-                  <Box
-                    onClick={() => handleMenuItemClick(ROUTES.PRIVACY_POLICY)}
-                    cursor="pointer"
-                    p={4}
-                    transition="background 0.2s"
-                    css={{ '&:hover': { bg: 'gray.50' } }}
-                  >
-                    <Text fontSize="md">プライバシーポリシー</Text>
-                  </Box>
+                  {menuItems.map((menuItem, index) => (
+                    <Box
+                      key={menuItem.path}
+                      onClick={() => handleMenuItemClick(menuItem.path)}
+                      {...menuItemStyle}
+                      borderBottom={
+                        index < menuItems.length - 1 ? '1px solid' : 'none'
+                      }
+                    >
+                      <Text fontSize="md">{menuItem.label}</Text>
+                    </Box>
+                  ))}
                 </VStack>
               </Drawer.Body>
             </Drawer.Content>
@@ -177,15 +185,12 @@ export const BottomNavigation = () => {
                   borderColor="gray.200"
                   css={{ pointerEvents: 'auto' }}
                 >
-                  <Box
-                    color={selected ? APP_CONFIG.COLORS.PRIMARY : 'gray.600'}
-                    transition="color 0.2s"
-                  >
+                  <Box color={getItemColor(selected)} transition="color 0.2s">
                     {selected ? item.activeIcon : item.icon}
                   </Box>
                   <Text
                     fontSize="xs"
-                    color={selected ? APP_CONFIG.COLORS.PRIMARY : 'gray.600'}
+                    color={getItemColor(selected)}
                     fontWeight={selected ? 'semibold' : 'normal'}
                     transition="all 0.2s"
                   >

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1,24 +1,13 @@
 import { Box, HStack, VStack, Text, Portal } from '@chakra-ui/react';
-import { IoHomeOutline, IoHome, IoMenuOutline, IoMenu } from 'react-icons/io5';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useState, useCallback, useMemo, useId } from 'react';
-import { ROUTES, type RoutePath } from '../constants/routes';
+import { useState, useCallback, useId } from 'react';
+import { ROUTES } from '../constants/routes';
 import { APP_CONFIG } from '../constants/app';
 import { NavigationDrawer } from './NavigationDrawer';
-
-/**
- * @description ナビゲーション項目のインターフェース
- */
-interface NavItem {
-  /** ナビゲーション項目のラベル */
-  readonly label: string;
-  /** ナビゲーション先のパス - Branded Typeによる型安全性 */
-  readonly path: RoutePath;
-  /** 通常状態のアイコン */
-  readonly icon: React.ReactNode;
-  /** アクティブ状態のアイコン */
-  readonly activeIcon: React.ReactNode;
-}
+import {
+  BOTTOM_NAVIGATION_ITEMS,
+  type NavigationItem,
+} from '../constants/navigation';
 
 /**
  * @description 底部ナビゲーションコンポーネント - 底部の固定ナビゲーションバーを提供
@@ -34,24 +23,7 @@ export const BottomNavigation = () => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const navId = useId();
 
-  const navItems = useMemo(
-    () =>
-      [
-        {
-          label: 'ホーム',
-          path: ROUTES.HOME as RoutePath,
-          icon: <IoHomeOutline size={24} aria-hidden="true" />,
-          activeIcon: <IoHome size={24} aria-hidden="true" />,
-        },
-        {
-          label: 'メニュー',
-          path: '#menu' as RoutePath,
-          icon: <IoMenuOutline size={24} aria-hidden="true" />,
-          activeIcon: <IoMenu size={24} aria-hidden="true" />,
-        },
-      ] as const satisfies readonly NavItem[],
-    []
-  );
+  const navItems = BOTTOM_NAVIGATION_ITEMS;
 
   // KISS: 色の取得をシンプル化
   const getItemColor = (isSelected: boolean) =>
@@ -62,7 +34,7 @@ export const BottomNavigation = () => {
    * @param item - クリックされたナビゲーション項目
    */
   const handleNavClick = useCallback(
-    (item: NavItem) => {
+    (item: NavigationItem) => {
       if (item.path === '#menu') {
         setIsDrawerOpen((prev) => !prev);
       } else {
@@ -79,7 +51,7 @@ export const BottomNavigation = () => {
    * @param item - 対象のナビゲーション項目
    */
   const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent, item: NavItem) => {
+    (event: React.KeyboardEvent, item: NavigationItem) => {
       if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault();
         handleNavClick(item);

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -23,23 +23,24 @@ export const Layout = ({
   rightButton,
   showDefaultTitle = true,
 }: LayoutProps) => {
-  const shouldShowHeader = headerTitle || showDefaultTitle;
-  const title = headerTitle || APP_CONFIG.APP_NAME;
+  const shouldShowHeader = Boolean(headerTitle) || showDefaultTitle;
+  const displayTitle =
+    headerTitle ?? (showDefaultTitle ? APP_CONFIG.APP_NAME : '');
 
   return (
     <Box minH="100vh" bg="gray.50">
-      <Box as="header" bg="white" shadow="sm">
-        <Container maxW="container.xl" py={2}>
-          {shouldShowHeader && (
+      {shouldShowHeader && (
+        <Box as="header" bg="white" shadow="sm">
+          <Container maxW="container.xl" py={2}>
             <NurseryHeader
-              title={title}
+              title={displayTitle}
               variant={headerVariant}
               leftButton={leftButton}
               rightButton={rightButton}
             />
-          )}
-        </Container>
-      </Box>
+          </Container>
+        </Box>
+      )}
 
       <Container as="main" maxW="container.xl" py={4} pb="80px">
         {children || <Outlet />}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { Box, Container } from '@chakra-ui/react';
 import { Outlet } from 'react-router-dom';
 import type { ReactNode } from 'react';
 import { NurseryHeader } from './NurseryHeader';
+import { BottomNavigation } from './BottomNavigation';
 import { APP_CONFIG } from '../constants/app';
 import type { HeaderButton, HeaderVariant } from '../types/header';
 
@@ -40,9 +41,11 @@ export const Layout = ({
         </Container>
       </Box>
 
-      <Container as="main" maxW="container.xl" py={4}>
+      <Container as="main" maxW="container.xl" py={4} pb="80px">
         {children || <Outlet />}
       </Container>
+
+      <BottomNavigation />
     </Box>
   );
 };

--- a/src/components/NavigationDrawer.test.tsx
+++ b/src/components/NavigationDrawer.test.tsx
@@ -11,6 +11,7 @@ import {
   getDrawerMenuItemByLabel,
   setupErrorHandlingTest,
 } from '../test-utils/navigation';
+import { DRAWER_MENU_ITEMS } from '../constants/navigation';
 
 const mockNavigate = vi.fn<NavigateFunction>();
 const mockOnClose = vi.fn<NavigationDrawerProps['onClose']>();
@@ -69,35 +70,22 @@ describe('NavigationDrawer', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
-  it('メニュー項目をクリックすると該当ページに遷移し、onCloseが呼ばれる', async () => {
-    renderNavigationDrawer();
+  it.each(
+    DRAWER_MENU_ITEMS.map((item) => ({ label: item.label, path: item.path }))
+  )(
+    'メニュー項目「$label」をクリックすると該当ページに遷移し、onCloseが呼ばれる',
+    async ({ label, path }) => {
+      renderNavigationDrawer();
 
-    await screen.findByRole('dialog');
+      await screen.findByRole('dialog');
 
-    const aboutItem = getDrawerMenuItemByLabel('このアプリについて');
-    expect(aboutItem).toBeDefined();
+      const menuLink = screen.getByText(label);
+      await user.click(menuLink);
 
-    const aboutLink = screen.getByText(aboutItem!.label);
-    await user.click(aboutLink);
-
-    expect(mockNavigate).toHaveBeenCalledWith(aboutItem!.path);
-    expect(mockOnClose).toHaveBeenCalled();
-  });
-
-  it('プライバシーポリシーリンクをクリックすると正しいページに遷移し、onCloseが呼ばれる', async () => {
-    renderNavigationDrawer();
-
-    await screen.findByRole('dialog');
-
-    const privacyItem = getDrawerMenuItemByLabel('プライバシーポリシー');
-    expect(privacyItem).toBeDefined();
-
-    const privacyPolicyLink = screen.getByText(privacyItem!.label);
-    await user.click(privacyPolicyLink);
-
-    expect(mockNavigate).toHaveBeenCalledWith(privacyItem!.path);
-    expect(mockOnClose).toHaveBeenCalled();
-  });
+      expect(mockNavigate).toHaveBeenCalledWith(path);
+      expect(mockOnClose).toHaveBeenCalled();
+    }
+  );
 
   it('閉じるボタンでメニューを閉じることができる', async () => {
     const { user } = renderNavigationDrawer();
@@ -106,10 +94,6 @@ describe('NavigationDrawer', () => {
     const dialog = await screen.findByRole('dialog');
     expect(dialog).toBeInTheDocument();
     expect(dialog).toHaveAttribute('data-state', 'open');
-
-    const aboutItem = getDrawerMenuItemByLabel('このアプリについて');
-    expect(aboutItem).toBeDefined();
-    expect(screen.getByText(aboutItem!.label)).toBeInTheDocument();
 
     // 閉じるボタンを見つけてクリック
     const closeButton = screen.getByRole('button', { name: /close/i });

--- a/src/components/NavigationDrawer.test.tsx
+++ b/src/components/NavigationDrawer.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { NavigateFunction } from 'react-router-dom';
+import { renderWithProviders } from '../test/test-utils';
+import { NavigationDrawer } from './NavigationDrawer';
+import { ROUTES } from '../constants/routes';
+
+const mockNavigate = vi.fn<NavigateFunction>();
+const mockOnClose = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const renderNavigationDrawer = (props = {}) => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: mockOnClose,
+    ...props,
+  };
+
+  return renderWithProviders(<NavigationDrawer {...defaultProps} />);
+};
+
+describe('NavigationDrawer', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+    mockNavigate.mockClear();
+    mockOnClose.mockClear();
+  });
+
+  it('isOpenがtrueの時にメニューが表示される', async () => {
+    renderNavigationDrawer({ isOpen: true });
+
+    await screen.findByRole('dialog');
+    expect(screen.getByText('メニュー')).toBeInTheDocument();
+    expect(screen.getByText('このアプリについて')).toBeInTheDocument();
+    expect(screen.getByText('プライバシーポリシー')).toBeInTheDocument();
+  });
+
+  it('isOpenがfalseの時にメニューが表示されない', () => {
+    renderNavigationDrawer({ isOpen: false });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('メニュー項目をクリックすると該当ページに遷移し、onCloseが呼ばれる', async () => {
+    renderNavigationDrawer();
+
+    await screen.findByRole('dialog');
+    const aboutLink = screen.getByText('このアプリについて');
+    await user.click(aboutLink);
+
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.ABOUT);
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('プライバシーポリシーリンクをクリックすると正しいページに遷移し、onCloseが呼ばれる', async () => {
+    renderNavigationDrawer();
+
+    await screen.findByRole('dialog');
+    const privacyPolicyLink = screen.getByText('プライバシーポリシー');
+    await user.click(privacyPolicyLink);
+
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.PRIVACY_POLICY);
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('Escapeキーでメニューを閉じることができる', async () => {
+    renderNavigationDrawer();
+
+    await screen.findByRole('dialog');
+    expect(screen.getByText('このアプリについて')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('メニューアイテムをクリックで選択できる', async () => {
+    renderNavigationDrawer();
+
+    await screen.findByRole('dialog');
+
+    const aboutMenuItem = screen.getByText('このアプリについて');
+    await user.click(aboutMenuItem);
+
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.ABOUT);
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  describe('エラーハンドリング', () => {
+    it('ナビゲーション失敗時にエラーを適切に処理する', async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const mockNavigateError = vi
+        .fn()
+        .mockRejectedValue(new Error('Navigation failed'));
+
+      // 一時的にモックを変更
+      const originalMockNavigate = mockNavigate;
+      vi.mocked(mockNavigate).mockImplementation(mockNavigateError);
+
+      renderNavigationDrawer();
+      await screen.findByRole('dialog');
+      const aboutLink = screen.getByText('このアプリについて');
+
+      await user.click(aboutLink);
+
+      // エラーが発生してもアプリがクラッシュしないことを確認
+      expect(screen.getByText('このアプリについて')).toBeInTheDocument();
+      expect(mockOnClose).toHaveBeenCalled();
+
+      // モックを元に戻す
+      vi.mocked(mockNavigate).mockImplementation(originalMockNavigate);
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/src/components/NavigationDrawer.tsx
+++ b/src/components/NavigationDrawer.tsx
@@ -1,0 +1,120 @@
+import {
+  Box,
+  VStack,
+  Text,
+  Drawer,
+  Portal,
+  CloseButton,
+} from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+import { useCallback } from 'react';
+import { ROUTES, type RoutePath } from '../constants/routes';
+import { APP_CONFIG } from '../constants/app';
+
+/**
+ * @description メニュー項目のインターフェース
+ */
+interface MenuItem {
+  /** メニュー項目のパス - Branded Typeによる型安全性 */
+  readonly path: RoutePath;
+  /** メニュー項目のラベル */
+  readonly label: string;
+}
+
+/**
+ * @description NavigationDrawerコンポーネントのProps
+ */
+interface NavigationDrawerProps {
+  /** Drawerの開閉状態 */
+  isOpen: boolean;
+  /** Drawerの開閉状態変更コールバック */
+  onClose: () => void;
+}
+
+/**
+ * @description ナビゲーション用のDrawerコンポーネント
+ * @param props - NavigationDrawerProps
+ * @returns DrawerのJSX要素
+ * @example
+ * ```tsx
+ * <NavigationDrawer isOpen={isDrawerOpen} onClose={() => setIsDrawerOpen(false)} />
+ * ```
+ */
+export const NavigationDrawer = ({
+  isOpen,
+  onClose,
+}: NavigationDrawerProps) => {
+  const navigate = useNavigate();
+
+  // DRY: メニューアイテムの設定を配列化
+  const menuItems = [
+    { path: ROUTES.ABOUT as RoutePath, label: 'このアプリについて' },
+    { path: ROUTES.PRIVACY_POLICY as RoutePath, label: 'プライバシーポリシー' },
+  ] as const satisfies readonly MenuItem[];
+
+  // DRY: 共通スタイルの定義
+  const menuItemStyle = {
+    cursor: 'pointer' as const,
+    p: 4,
+    borderBottom: '1px solid',
+    borderColor: 'gray.100',
+    transition: 'background 0.2s',
+    css: { '&:hover': { bg: 'gray.50' } },
+  };
+
+  /**
+   * @description メニュー項目のクリックハンドラ
+   * @param path - 遷移先のパス
+   */
+  const handleMenuItemClick = useCallback(
+    (path: string) => {
+      void navigate(path);
+      onClose();
+    },
+    [navigate, onClose]
+  );
+
+  return (
+    <Drawer.Root
+      open={isOpen}
+      onOpenChange={(e) => !e.open && onClose()}
+      size="sm"
+    >
+      <Portal>
+        <Drawer.Backdrop />
+        <Drawer.Positioner>
+          <Drawer.Content maxW="280px">
+            <Drawer.Header borderBottom="1px solid" borderColor="gray.200">
+              <Drawer.Title
+                fontSize="lg"
+                fontWeight="semibold"
+                color={APP_CONFIG.COLORS.PRIMARY}
+              >
+                メニュー
+              </Drawer.Title>
+              <Drawer.CloseTrigger asChild>
+                <CloseButton size="md" />
+              </Drawer.CloseTrigger>
+            </Drawer.Header>
+            <Drawer.Body p={0}>
+              <VStack align="stretch" gap={0}>
+                {menuItems.map((menuItem, index) => (
+                  <Box
+                    key={menuItem.path}
+                    onClick={() => handleMenuItemClick(menuItem.path)}
+                    {...menuItemStyle}
+                    borderBottom={
+                      index < menuItems.length - 1 ? '1px solid' : 'none'
+                    }
+                  >
+                    <Text fontSize="md">{menuItem.label}</Text>
+                  </Box>
+                ))}
+              </VStack>
+            </Drawer.Body>
+          </Drawer.Content>
+        </Drawer.Positioner>
+      </Portal>
+    </Drawer.Root>
+  );
+};

--- a/src/components/NavigationDrawer.tsx
+++ b/src/components/NavigationDrawer.tsx
@@ -14,7 +14,7 @@ import { DRAWER_MENU_ITEMS } from '../constants/navigation';
 /**
  * @description NavigationDrawerコンポーネントのProps
  */
-interface NavigationDrawerProps {
+export interface NavigationDrawerProps {
   /** Drawerの開閉状態 */
   isOpen: boolean;
   /** Drawerの開閉状態変更コールバック */

--- a/src/components/NavigationDrawer.tsx
+++ b/src/components/NavigationDrawer.tsx
@@ -8,18 +8,8 @@ import {
 } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 import { useCallback, useId } from 'react';
-import { ROUTES, type RoutePath } from '../constants/routes';
 import { APP_CONFIG } from '../constants/app';
-
-/**
- * @description メニュー項目のインターフェース
- */
-interface MenuItem {
-  /** メニュー項目のパス - Branded Typeによる型安全性 */
-  readonly path: RoutePath;
-  /** メニュー項目のラベル */
-  readonly label: string;
-}
+import { DRAWER_MENU_ITEMS } from '../constants/navigation';
 
 /**
  * @description NavigationDrawerコンポーネントのProps
@@ -51,11 +41,8 @@ export const NavigationDrawer = ({
   const drawerId = useId();
   const titleId = `${drawerId}-title`;
 
-  // DRY: メニューアイテムの設定を配列化
-  const menuItems = [
-    { path: ROUTES.ABOUT as RoutePath, label: 'このアプリについて' },
-    { path: ROUTES.PRIVACY_POLICY as RoutePath, label: 'プライバシーポリシー' },
-  ] as const satisfies readonly MenuItem[];
+  // DRY: メニューアイテムの設定を共通定数から取得
+  const menuItems = DRAWER_MENU_ITEMS;
 
   // DRY: 共通スタイルの定義
   const menuItemStyle = {

--- a/src/components/NurseryHeader.test.tsx
+++ b/src/components/NurseryHeader.test.tsx
@@ -525,7 +525,12 @@ describe('NurseryHeader', () => {
       await user.keyboard('{Enter}');
       expect(mockLeftClick).toHaveBeenCalledTimes(1);
 
-      // Tabキーで右ボタンにフォーカス
+      // Tabキーでタイトルリンクにフォーカス（新しく追加された）
+      await user.tab();
+      const titleLink = screen.getByRole('link');
+      expect(titleLink).toHaveFocus();
+
+      // もう一度Tabキーで右ボタンにフォーカス
       await user.tab();
       const rightBtn = screen.getByRole('button', { name: '保存' });
       expect(rightBtn).toHaveFocus();

--- a/src/components/NurseryHeader.tsx
+++ b/src/components/NurseryHeader.tsx
@@ -4,17 +4,36 @@
 
 import { Box, Button, Heading, HStack, IconButton } from '@chakra-ui/react';
 import { IoHelpCircleOutline } from 'react-icons/io5';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { APP_CONFIG } from '../constants/app';
 import type { HeaderButton, HeaderVariant } from '../types/header';
 
+/**
+ * @description ヘッダーコンポーネントのプロパティ
+ */
 interface NurseryHeaderProps {
+  /** ヘッダーのタイトル */
   title: string;
+  /** 左側のボタン設定（オプション） */
   leftButton?: HeaderButton;
+  /** 右側のボタン設定（オプション） */
   rightButton?: HeaderButton;
+  /** ヘッダーの表示バリアント */
   variant?: HeaderVariant;
 }
 
+/**
+ * @description 共通ヘッダーコンポーネント - アプリケーションの上部に表示される
+ * @param props - ヘッダーコンポーネントのプロパティ
+ * @returns ヘッダーのJSX要素
+ * @example
+ * ```tsx
+ * <NurseryHeader
+ *   title="保活手帳"
+ *   variant="centered"
+ * />
+ * ```
+ */
 export const NurseryHeader = ({
   title,
   leftButton,
@@ -30,14 +49,19 @@ export const NurseryHeader = ({
   };
   if (variant === 'centered') {
     return (
-      <Heading
-        as="h1"
-        size={{ base: 'md', md: 'lg' }}
-        color={APP_CONFIG.COLORS.PRIMARY}
-        textAlign="center"
-      >
-        {title}
-      </Heading>
+      <Link to="/" style={{ textDecoration: 'none' }}>
+        <Heading
+          as="h1"
+          size={{ base: 'md', md: 'lg' }}
+          color={APP_CONFIG.COLORS.PRIMARY}
+          textAlign="center"
+          cursor="pointer"
+          transition="opacity 0.2s"
+          css={{ '&:hover': { opacity: 0.8 } }}
+        >
+          {title}
+        </Heading>
+      </Link>
     );
   }
 
@@ -51,7 +75,7 @@ export const NurseryHeader = ({
             aria-label={leftButton['aria-label'] || 'Action button'}
             size={{ base: 'sm', md: 'md' }}
             borderRadius="full"
-            _hover={{ bg: 'gray.100' }}
+            css={{ '&:hover': { bg: 'gray.100' } }}
           >
             {leftButton.icon}
           </IconButton>
@@ -69,15 +93,19 @@ export const NurseryHeader = ({
         <Box w="40px" />
       )}
 
-      <Heading
-        as="h1"
-        size={{ base: 'md', md: 'lg' }}
-        color={APP_CONFIG.COLORS.PRIMARY}
-        flex={1}
-        textAlign="center"
-      >
-        {title}
-      </Heading>
+      <Link to="/" style={{ textDecoration: 'none', flex: 1 }}>
+        <Heading
+          as="h1"
+          size={{ base: 'md', md: 'lg' }}
+          color={APP_CONFIG.COLORS.PRIMARY}
+          textAlign="center"
+          cursor="pointer"
+          transition="opacity 0.2s"
+          css={{ '&:hover': { opacity: 0.8 } }}
+        >
+          {title}
+        </Heading>
+      </Link>
 
       {(() => {
         const buttonToShow = rightButton || defaultHelpButton;
@@ -95,7 +123,7 @@ export const NurseryHeader = ({
               aria-label={buttonToShow['aria-label'] || 'Action button'}
               size={{ base: 'sm', md: 'md' }}
               borderRadius="full"
-              _hover={{ bg: 'gray.100' }}
+              css={{ '&:hover': { bg: 'gray.100' } }}
             >
               {buttonToShow.icon}
             </IconButton>

--- a/src/components/NurseryHeader.tsx
+++ b/src/components/NurseryHeader.tsx
@@ -5,6 +5,7 @@
 import { Box, Button, Heading, HStack, IconButton } from '@chakra-ui/react';
 import { IoHelpCircleOutline } from 'react-icons/io5';
 import { useNavigate, Link } from 'react-router-dom';
+import { useMemo } from 'react';
 import { APP_CONFIG } from '../constants/app';
 import type { HeaderButton, HeaderVariant } from '../types/header';
 
@@ -34,6 +35,44 @@ interface NurseryHeaderProps {
  * />
  * ```
  */
+/**
+ * @description ヘッダーボタンの表示ロジックをカスタムフック化
+ */
+const useHeaderButton = (
+  rightButton?: HeaderButton,
+  defaultButton?: HeaderButton
+) => {
+  return useMemo(() => {
+    const buttonToShow = rightButton || defaultButton;
+    const shouldShow = buttonToShow && !buttonToShow.hidden;
+
+    if (!shouldShow) {
+      return <Box w="40px" />;
+    }
+
+    const commonProps = {
+      onClick: buttonToShow.onClick,
+      variant: buttonToShow.variant || 'ghost',
+      size: { base: 'sm', md: 'md' } as const,
+    };
+
+    if (buttonToShow.icon) {
+      return (
+        <IconButton
+          {...commonProps}
+          aria-label={buttonToShow['aria-label'] || 'Action button'}
+          borderRadius="full"
+          css={{ '&:hover': { bg: 'gray.100' } }}
+        >
+          {buttonToShow.icon}
+        </IconButton>
+      );
+    }
+
+    return <Button {...commonProps}>{buttonToShow.text}</Button>;
+  }, [rightButton, defaultButton]);
+};
+
 export const NurseryHeader = ({
   title,
   leftButton,
@@ -42,11 +81,16 @@ export const NurseryHeader = ({
 }: NurseryHeaderProps) => {
   const navigate = useNavigate();
 
-  const defaultHelpButton: HeaderButton = {
-    icon: <IoHelpCircleOutline />,
-    onClick: () => void navigate('/about'),
-    'aria-label': 'ヘルプ',
-  };
+  const defaultHelpButton: HeaderButton = useMemo(
+    () => ({
+      icon: <IoHelpCircleOutline />,
+      onClick: () => void navigate('/about'),
+      'aria-label': 'ヘルプ',
+    }),
+    [navigate]
+  );
+
+  const rightButtonElement = useHeaderButton(rightButton, defaultHelpButton);
   if (variant === 'centered') {
     return (
       <Link to="/" style={{ textDecoration: 'none' }}>
@@ -107,39 +151,7 @@ export const NurseryHeader = ({
         </Heading>
       </Link>
 
-      {(() => {
-        const buttonToShow = rightButton || defaultHelpButton;
-        const shouldShow = buttonToShow && !buttonToShow.hidden;
-
-        if (!shouldShow) {
-          return <Box w="40px" />;
-        }
-
-        if (buttonToShow.icon) {
-          return (
-            <IconButton
-              onClick={buttonToShow.onClick}
-              variant={buttonToShow.variant || 'ghost'}
-              aria-label={buttonToShow['aria-label'] || 'Action button'}
-              size={{ base: 'sm', md: 'md' }}
-              borderRadius="full"
-              css={{ '&:hover': { bg: 'gray.100' } }}
-            >
-              {buttonToShow.icon}
-            </IconButton>
-          );
-        }
-
-        return (
-          <Button
-            variant={buttonToShow.variant || 'ghost'}
-            onClick={buttonToShow.onClick}
-            size={{ base: 'sm', md: 'md' }}
-          >
-            {buttonToShow.text}
-          </Button>
-        );
-      })()}
+      {rightButtonElement}
     </HStack>
   );
 };

--- a/src/constants/navigation.tsx
+++ b/src/constants/navigation.tsx
@@ -1,0 +1,137 @@
+import { IoHomeOutline, IoHome, IoMenuOutline, IoMenu } from 'react-icons/io5';
+import { ROUTES, type RoutePath } from './routes';
+
+/**
+ * @description ナビゲーション項目のインターフェース
+ */
+export interface NavigationItem {
+  /** ナビゲーション項目のラベル */
+  readonly label: string;
+  /** ナビゲーション先のパス - Branded Typeによる型安全性 */
+  readonly path: RoutePath;
+  /** 通常状態のアイコン */
+  readonly icon: React.ReactNode;
+  /** アクティブ状態のアイコン */
+  readonly activeIcon: React.ReactNode;
+}
+
+/**
+ * @description メニュー項目のインターフェース
+ */
+export interface MenuItem {
+  /** メニュー項目のパス - Branded Typeによる型安全性 */
+  readonly path: RoutePath;
+  /** メニュー項目のラベル */
+  readonly label: string;
+}
+
+/**
+ * @description 底部ナビゲーション項目の定義
+ * ホームとメニューボタンを含む
+ */
+export const BOTTOM_NAVIGATION_ITEMS = [
+  {
+    label: 'ホーム',
+    path: ROUTES.HOME as RoutePath,
+    icon: <IoHomeOutline size={24} aria-hidden="true" />,
+    activeIcon: <IoHome size={24} aria-hidden="true" />,
+  },
+  {
+    label: 'メニュー',
+    path: '#menu' as RoutePath,
+    icon: <IoMenuOutline size={24} aria-hidden="true" />,
+    activeIcon: <IoMenu size={24} aria-hidden="true" />,
+  },
+] as const satisfies readonly NavigationItem[];
+
+/**
+ * @description Drawerメニュー項目の定義
+ * このアプリについて、プライバシーポリシーなどの静的ページへのリンク
+ */
+export const DRAWER_MENU_ITEMS = [
+  { path: ROUTES.ABOUT as RoutePath, label: 'このアプリについて' },
+  { path: ROUTES.PRIVACY_POLICY as RoutePath, label: 'プライバシーポリシー' },
+] as const satisfies readonly MenuItem[];
+
+/**
+ * @description ナビゲーション関連の型定義
+ */
+export type NavigationValue = (typeof BOTTOM_NAVIGATION_ITEMS)[number]['path'];
+export type MenuValue = (typeof DRAWER_MENU_ITEMS)[number]['path'];
+
+/**
+ * @description 底部ナビゲーション項目のラベル型
+ */
+export type BottomNavigationLabel =
+  (typeof BOTTOM_NAVIGATION_ITEMS)[number]['label'];
+
+/**
+ * @description Drawerメニュー項目のラベル型
+ */
+export type DrawerMenuLabel = (typeof DRAWER_MENU_ITEMS)[number]['label'];
+
+/**
+ * @description ナビゲーション項目取得の型安全なヘルパー
+ */
+export const NAVIGATION_HELPERS = {
+  /**
+   * パスから底部ナビゲーション項目を取得（型安全）
+   */
+  getBottomNavItemByPath: (
+    path: NavigationValue
+  ): (typeof BOTTOM_NAVIGATION_ITEMS)[number] | undefined =>
+    BOTTOM_NAVIGATION_ITEMS.find((item) => item.path === path),
+
+  /**
+   * ラベルから底部ナビゲーション項目を取得（型安全）
+   */
+  getBottomNavItemByLabel: (
+    label: BottomNavigationLabel
+  ): (typeof BOTTOM_NAVIGATION_ITEMS)[number] | undefined =>
+    BOTTOM_NAVIGATION_ITEMS.find((item) => item.label === label),
+
+  /**
+   * パスからDrawerメニュー項目を取得（型安全）
+   */
+  getDrawerItemByPath: (
+    path: MenuValue
+  ): (typeof DRAWER_MENU_ITEMS)[number] | undefined =>
+    DRAWER_MENU_ITEMS.find((item) => item.path === path),
+
+  /**
+   * ラベルからDrawerメニュー項目を取得（型安全）
+   */
+  getDrawerItemByLabel: (
+    label: DrawerMenuLabel
+  ): (typeof DRAWER_MENU_ITEMS)[number] | undefined =>
+    DRAWER_MENU_ITEMS.find((item) => item.label === label),
+} as const;
+
+/**
+ * @description ナビゲーション項目の検証ヘルパー
+ */
+export const NAVIGATION_VALIDATORS = {
+  /**
+   * 指定されたパスが有効な底部ナビゲーションパスかどうかを判定
+   */
+  isValidBottomNavPath: (path: string): path is NavigationValue =>
+    BOTTOM_NAVIGATION_ITEMS.some((item) => item.path === path),
+
+  /**
+   * 指定されたパスが有効なDrawerメニューパスかどうかを判定
+   */
+  isValidDrawerMenuPath: (path: string): path is MenuValue =>
+    DRAWER_MENU_ITEMS.some((item) => item.path === path),
+
+  /**
+   * 指定されたラベルが有効な底部ナビゲーションラベルかどうかを判定
+   */
+  isValidBottomNavLabel: (label: string): label is BottomNavigationLabel =>
+    BOTTOM_NAVIGATION_ITEMS.some((item) => item.label === label),
+
+  /**
+   * 指定されたラベルが有効なDrawerメニューラベルかどうかを判定
+   */
+  isValidDrawerMenuLabel: (label: string): label is DrawerMenuLabel =>
+    DRAWER_MENU_ITEMS.some((item) => item.label === label),
+} as const;

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -51,6 +51,11 @@ export const generateRoute = {
 } as const;
 
 /**
+ * Branded Type for route paths - より型安全なルートパス
+ */
+export type RoutePath = string & { readonly __brand: unique symbol };
+
+/**
  * ルートパスの型定義
  */
 export type RouteKeys = keyof typeof ROUTES;

--- a/src/hooks/useNavigation.test.ts
+++ b/src/hooks/useNavigation.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { NavigateFunction } from 'react-router-dom';
+import { useNavigation } from './useNavigation';
+import { ROUTES } from '../constants/routes';
+
+// React Router関連のモック
+const mockNavigate = vi.fn<NavigateFunction>();
+const mockLocation = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => mockLocation(),
+  };
+});
+
+describe('useNavigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLocation.mockReturnValue({
+      pathname: '/',
+      search: '',
+      hash: '',
+      state: null,
+      key: 'default',
+    });
+  });
+
+  describe('handleNavigation', () => {
+    it('正常なナビゲーションが実行される', () => {
+      const { result } = renderHook(() => useNavigation());
+
+      act(() => {
+        result.current.handleNavigation('/about');
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith('/about', undefined);
+    });
+
+    it('ナビゲーションオプション付きで実行される', () => {
+      const { result } = renderHook(() => useNavigation());
+
+      act(() => {
+        result.current.handleNavigation('/about', { replace: true });
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith('/about', { replace: true });
+    });
+
+    it('ナビゲーションエラー時にホームページにフォールバックする', () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      mockNavigate.mockImplementationOnce(() => {
+        throw new Error('Navigation failed');
+      });
+
+      const { result } = renderHook(() => useNavigation());
+
+      act(() => {
+        result.current.handleNavigation('/invalid-path');
+      });
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Navigation failed:',
+        expect.any(Error)
+      );
+      expect(mockNavigate).toHaveBeenCalledWith(ROUTES.HOME, { replace: true });
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('isHomePage', () => {
+    it('ホームページパス("/")の場合、trueを返す', () => {
+      mockLocation.mockReturnValue({
+        pathname: '/',
+        search: '',
+        hash: '',
+        state: null,
+        key: 'default',
+      });
+
+      const { result } = renderHook(() => useNavigation());
+      expect(result.current.isHomePage()).toBe(true);
+    });
+
+    it('空文字パスの場合、trueを返す', () => {
+      mockLocation.mockReturnValue({
+        pathname: '',
+        search: '',
+        hash: '',
+        state: null,
+        key: 'default',
+      });
+
+      const { result } = renderHook(() => useNavigation());
+      expect(result.current.isHomePage()).toBe(true);
+    });
+
+    it('他のパスの場合、falseを返す', () => {
+      mockLocation.mockReturnValue({
+        pathname: '/about',
+        search: '',
+        hash: '',
+        state: null,
+        key: 'default',
+      });
+
+      const { result } = renderHook(() => useNavigation());
+      expect(result.current.isHomePage()).toBe(false);
+    });
+  });
+
+  describe('isCurrentPath', () => {
+    it('現在のパスと一致する場合、trueを返す', () => {
+      mockLocation.mockReturnValue({
+        pathname: '/about',
+        search: '',
+        hash: '',
+        state: null,
+        key: 'default',
+      });
+
+      const { result } = renderHook(() => useNavigation());
+      expect(result.current.isCurrentPath('/about')).toBe(true);
+    });
+
+    it('現在のパスと異なる場合、falseを返す', () => {
+      mockLocation.mockReturnValue({
+        pathname: '/about',
+        search: '',
+        hash: '',
+        state: null,
+        key: 'default',
+      });
+
+      const { result } = renderHook(() => useNavigation());
+      expect(result.current.isCurrentPath('/privacy-policy')).toBe(false);
+    });
+  });
+
+  describe('isValidNavigationPath', () => {
+    it('有効な底部ナビゲーションパスの場合、trueを返す', () => {
+      const { result } = renderHook(() => useNavigation());
+      expect(result.current.isValidNavigationPath('/')).toBe(true);
+    });
+
+    it('有効なDrawerメニューパスの場合、trueを返す', () => {
+      const { result } = renderHook(() => useNavigation());
+      expect(result.current.isValidNavigationPath('/about')).toBe(true);
+    });
+
+    it('アンカーリンクの場合、trueを返す', () => {
+      const { result } = renderHook(() => useNavigation());
+      expect(result.current.isValidNavigationPath('#menu')).toBe(true);
+    });
+
+    it('無効なパスの場合、falseを返す', () => {
+      const { result } = renderHook(() => useNavigation());
+      expect(result.current.isValidNavigationPath('/invalid-path')).toBe(false);
+    });
+  });
+
+  describe('getCurrentLocation', () => {
+    it('現在の場所情報を正しく返す', () => {
+      const mockLocationData = {
+        pathname: '/about',
+        search: '?param=value',
+        hash: '#section',
+        state: null,
+        key: 'default',
+      };
+
+      mockLocation.mockReturnValue(mockLocationData);
+
+      const { result } = renderHook(() => useNavigation());
+      const locationInfo = result.current.getCurrentLocation();
+
+      expect(locationInfo).toEqual({
+        pathname: '/about',
+        search: '?param=value',
+        hash: '#section',
+        isHome: false,
+      });
+    });
+
+    it('ホームページの場合、isHomeがtrueになる', () => {
+      mockLocation.mockReturnValue({
+        pathname: '/',
+        search: '',
+        hash: '',
+        state: null,
+        key: 'default',
+      });
+
+      const { result } = renderHook(() => useNavigation());
+      const locationInfo = result.current.getCurrentLocation();
+
+      expect(locationInfo.isHome).toBe(true);
+    });
+  });
+});

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -1,0 +1,104 @@
+import { useCallback } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { ROUTES } from '../constants/routes';
+import { NAVIGATION_VALIDATORS } from '../constants/navigation';
+
+/**
+ * @description ナビゲーション関連の共通ロジックを提供するカスタムフック
+ * @returns ナビゲーション関連の関数と状態
+ *
+ * @example
+ * ```tsx
+ * const { handleNavigation, isHomePage, isCurrentPath } = useNavigation();
+ *
+ * // 安全なナビゲーション
+ * handleNavigation('/about');
+ *
+ * // 現在のページ判定
+ * if (isHomePage()) {
+ *   // ホームページ固有の処理
+ * }
+ *
+ * // 任意のパスの判定
+ * if (isCurrentPath('/about')) {
+ *   // このページ固有の処理
+ * }
+ * ```
+ */
+export const useNavigation = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  /**
+   * @description 型安全なナビゲーション処理
+   * @param path - ナビゲーション先のパス
+   * @param options - ナビゲーションオプション
+   */
+  const handleNavigation = useCallback(
+    (path: string, options?: { replace?: boolean }) => {
+      try {
+        void navigate(path, options);
+      } catch (error) {
+        console.error('Navigation failed:', error);
+        // フォールバック：ホームページに戻る
+        void navigate(ROUTES.HOME, { replace: true });
+      }
+    },
+    [navigate]
+  );
+
+  /**
+   * @description 現在のページがホームページかどうかを判定
+   * @returns ホームページの場合true
+   */
+  const isHomePage = useCallback((): boolean => {
+    return location.pathname === ROUTES.HOME || location.pathname === '';
+  }, [location.pathname]);
+
+  /**
+   * @description 指定されたパスが現在のパスと一致するかを判定
+   * @param path - 判定対象のパス
+   * @returns 一致する場合true
+   */
+  const isCurrentPath = useCallback(
+    (path: string): boolean => {
+      return location.pathname === path;
+    },
+    [location.pathname]
+  );
+
+  /**
+   * @description 指定されたパスが有効なナビゲーションパスかを判定
+   * @param path - 判定対象のパス
+   * @returns 有効な場合true
+   */
+  const isValidNavigationPath = useCallback((path: string): boolean => {
+    return (
+      NAVIGATION_VALIDATORS.isValidBottomNavPath(path) ||
+      NAVIGATION_VALIDATORS.isValidDrawerMenuPath(path) ||
+      path.startsWith('#')
+    ); // アンカーリンクも許可
+  }, []);
+
+  /**
+   * @description 現在の場所情報を取得
+   * @returns location情報とヘルパー関数
+   */
+  const getCurrentLocation = useCallback(() => {
+    return {
+      pathname: location.pathname,
+      search: location.search,
+      hash: location.hash,
+      isHome: isHomePage(),
+    };
+  }, [location, isHomePage]);
+
+  return {
+    handleNavigation,
+    isHomePage,
+    isCurrentPath,
+    isValidNavigationPath,
+    getCurrentLocation,
+    location,
+  };
+};

--- a/src/test-utils/navigation.ts
+++ b/src/test-utils/navigation.ts
@@ -1,0 +1,159 @@
+import { vi } from 'vitest';
+import type { NavigateFunction } from 'react-router-dom';
+import {
+  BOTTOM_NAVIGATION_ITEMS,
+  DRAWER_MENU_ITEMS,
+} from '../constants/navigation';
+import { ROUTES } from '../constants/routes';
+
+/**
+ * @description モックナビゲーション関数を作成する
+ * @returns モックされたnavigate関数
+ */
+export const createMockNavigate = () => vi.fn();
+
+/**
+ * @description モックロケーションオブジェクトを作成する
+ * @param pathname - パス名 (デフォルト: '/')
+ * @returns モックされたlocationオブジェクト
+ */
+export const createMockLocation = (pathname: string = '/') => ({
+  pathname,
+  search: '',
+  hash: '',
+  state: null,
+  key: 'default',
+});
+
+/**
+ * @description パスから底部ナビゲーション項目を取得する
+ * @param path - 検索するパス
+ * @returns 見つかった項目、存在しない場合はundefined
+ */
+export const getBottomNavigationItemByPath = (path: string) =>
+  BOTTOM_NAVIGATION_ITEMS.find((item) => item.path === path);
+
+/**
+ * @description ラベルから底部ナビゲーション項目を取得する
+ * @param label - 検索するラベル
+ * @returns 見つかった項目、存在しない場合はundefined
+ */
+export const getBottomNavigationItemByLabel = (label: string) =>
+  BOTTOM_NAVIGATION_ITEMS.find((item) => item.label === label);
+
+/**
+ * @description パスからDrawerメニュー項目を取得する
+ * @param path - 検索するパス
+ * @returns 見つかった項目、存在しない場合はundefined
+ */
+export const getDrawerMenuItemByPath = (path: string) =>
+  DRAWER_MENU_ITEMS.find((item) => item.path === path);
+
+/**
+ * @description ラベルからDrawerメニュー項目を取得する
+ * @param label - 検索するラベル
+ * @returns 見つかった項目、存在しない場合はundefined
+ */
+export const getDrawerMenuItemByLabel = (label: string) =>
+  DRAWER_MENU_ITEMS.find((item) => item.label === label);
+
+/**
+ * @description テストでよく使用される定数をまとめたオブジェクト
+ */
+export const TEST_NAVIGATION_CONSTANTS = {
+  /** ホームページのパス */
+  HOME_PATH: ROUTES.HOME,
+  /** メニューの特別なパス */
+  MENU_PATH: '#menu',
+  /** 底部ナビゲーション項目数 */
+  BOTTOM_NAV_ITEMS_COUNT: BOTTOM_NAVIGATION_ITEMS.length,
+  /** Drawerメニュー項目数 */
+  DRAWER_MENU_ITEMS_COUNT: DRAWER_MENU_ITEMS.length,
+} as const;
+
+/**
+ * @description React Router関連のモックを一括で設定するヘルパー
+ * @param pathname - 初期パス名 (デフォルト: '/')
+ * @returns モック関数のオブジェクト
+ */
+export const setupNavigationMocks = (pathname: string = '/') => {
+  const mockNavigate = createMockNavigate();
+  const mockLocation = createMockLocation(pathname);
+
+  return {
+    mockNavigate,
+    mockLocation,
+  };
+};
+
+/**
+ * @description React Routerのモックを設定し、テスト用のナビゲーション関数を作成
+ * @returns モックされたnavigate関数
+ */
+export const createNavigationMock = () => {
+  const mockNavigate = vi.fn<NavigateFunction>();
+
+  vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom');
+    return {
+      ...actual,
+      useNavigate: () => mockNavigate,
+    };
+  });
+
+  return mockNavigate;
+};
+
+/**
+ * @description テスト共通のセットアップを行うヘルパー
+ * @returns テストで使用するモック関数群
+ */
+export const setupNavigationTest = () => {
+  const mockNavigate = vi.fn<NavigateFunction>();
+  const mockOnClose = vi.fn<() => void>();
+
+  const clearMocks = () => {
+    vi.clearAllMocks();
+  };
+
+  return {
+    mockNavigate,
+    mockOnClose,
+    clearMocks,
+  };
+};
+
+/**
+ * @description エラーハンドリングテスト用のヘルパー
+ * @param mockNavigate - モックされたnavigate関数
+ * @returns エラー処理テスト用の関数群
+ */
+export const setupErrorHandlingTest = (
+  mockNavigate: ReturnType<typeof vi.fn<NavigateFunction>>
+) => {
+  const consoleErrorSpy = vi
+    .spyOn(console, 'error')
+    .mockImplementation(() => {});
+  const mockNavigateError = vi.fn<NavigateFunction>();
+  mockNavigateError.mockRejectedValue(new Error('Navigation failed'));
+
+  // 一時的にモックを変更
+  const originalMockNavigate = mockNavigate.getMockImplementation();
+  mockNavigate.mockImplementation(mockNavigateError);
+
+  const restoreMocks = () => {
+    // モックを元に戻す
+    if (originalMockNavigate) {
+      mockNavigate.mockImplementation(originalMockNavigate);
+    } else {
+      mockNavigate.mockRestore();
+    }
+    consoleErrorSpy.mockRestore();
+  };
+
+  return {
+    consoleErrorSpy,
+    mockNavigateError,
+    restoreMocks,
+  };
+};


### PR DESCRIPTION
## Summary

- 🎯 底部固定ナビゲーションバーを実装
- 📱 Chakra UI v3 Drawerコンポーネントによるモバイルフレンドリーなメニュー
- 🏠 ヘッダータイトルをクリック可能にしてホームナビゲーション機能を追加

## 主な機能

### 底部ナビゲーション
- **ホームボタン**: トップページへの直接遷移
- **メニューボタン**: Drawerを開いてアプリメニュー表示
- **アクティブ状態**: 現在のページに応じたボタンの視覚的フィードバック
- **モバイル最適化**: 底部固定配置で指での操作がしやすい設計

### Drawerメニュー
- **このアプリについて**: アプリケーション情報ページへ
- **プライバシー設定**: プライバシー設定ページへ  
- **プライバシーポリシー**: プライバシーポリシーページへ
- **pointer-events対応**: Drawer表示時でもナビゲーション操作が可能

### ヘッダー改善
- **クリック可能なタイトル**: サイト名「保活手帳」をクリックでホームに戻る
- **ホバー効果**: ユーザビリティ向上のための視覚的フィードバック
- **アクセシビリティ**: フォーカス管理とキーボードナビゲーション対応

## 技術仕様

### 使用技術
- **Chakra UI v3**: Drawer、Portal、HStack、VStackコンポーネント
- **React Router**: useNavigate、useLocation、Linkコンポーネント
- **React Icons**: IoHomeOutline、IoHome、IoMenuOutline、IoMenu
- **TypeScript**: 完全な型安全性とベストプラクティス準拠

### パフォーマンス・UX配慮
- **z-index階層管理**: 適切な重ね順でDrawerとナビゲーションが共存
- **レスポンシブデザイン**: モバイルファーストの設計思想
- **アニメーション**: スムーズなDrawer開閉とホバー効果
- **状態管理**: Drawerの開閉状態と現在ページの適切な同期

## Test plan

- [x] 底部ナビゲーション表示確認
- [x] ホームボタンの遷移機能
- [x] メニューボタンのDrawer開閉
- [x] Drawer内メニュー項目の遷移機能
- [x] ヘッダータイトルのクリック機能
- [x] アクティブ状態の視覚的表示
- [x] pointer-events問題の解決確認
- [x] レスポンシブデザインの確認
- [x] TypeScriptコンパイルエラーなし
- [x] ESLint警告なし
- [x] 全49テストケースが通過

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 画面下部ナビゲーションを追加（ホーム/メニュー、現在地表示、キーボード操作対応）。
  - スライドアップのメニューを追加（このアプリについて、プライバシーポリシー）。
  - ヘッダーのタイトルをホームへのリンク化。レイアウトを下部ナビ分の余白に最適化。

- リファクタ
  - ヘッダーの構造とアクセシビリティを改善（表示条件の明確化、ホバー挙動の統一）。

- テスト
  - 下部ナビ、メニュー、ナビゲーション動作の包括的テストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->