### PR TITLE
feat(ui): UI改善とフォーム簡略化によるユーザビリティ向上

### DIFF
--- a/src/components/NurseryCard.test.tsx
+++ b/src/components/NurseryCard.test.tsx
@@ -331,14 +331,6 @@ describe('NurseryCard コンポーネント', () => {
       });
       expect(card).toBeInTheDocument();
     });
-
-    test('tabIndexが0に設定されてキーボードアクセス可能', () => {
-      const nursery = testUtils.createMockNursery();
-      renderWithProviders(<NurseryCard nursery={nursery} onClick={vi.fn()} />);
-
-      const card = screen.getByRole('button');
-      expect(card).toHaveAttribute('tabIndex', '0');
-    });
   });
 
   describe('気づきタグ表示', () => {

--- a/src/components/NurseryCard.tsx
+++ b/src/components/NurseryCard.tsx
@@ -3,7 +3,8 @@
  * 保育園情報をカード形式で表示し、見学状況と進捗を提供
  */
 
-import { Box, Text, VStack, HStack, Flex } from '@chakra-ui/react';
+import { Box, Text, VStack, HStack, Flex, Icon } from '@chakra-ui/react';
+import { IoChevronForward } from 'react-icons/io5';
 import type { Nursery } from '../types/entities';
 import { InsightTag } from './InsightTag';
 import { useNurseryStatus } from '../hooks/useNurseryStatus';
@@ -66,47 +67,54 @@ export const NurseryCard = ({ nursery, onClick }: NurseryCardProps) => {
       onClick={handleInteraction}
       onKeyDown={handleKeyDown}
     >
-      <VStack align="stretch" gap={3}>
-        {/* ヘッダー部分: 保育園名とバッジ */}
-        <HStack justify="space-between" align="flex-start">
-          <Text
-            fontWeight="bold"
-            fontSize="lg"
-            color="gray.800"
-            textAlign="left"
-            flex={1}
-            lineHeight="1.3"
-          >
-            {nursery.name}
-          </Text>
-        </HStack>
+      <HStack align="center" gap={3} width="100%">
+        <VStack align="stretch" gap={3} flex={1}>
+          {/* ヘッダー部分: 保育園名とバッジ */}
+          <HStack justify="space-between" align="center">
+            <Text
+              fontWeight="bold"
+              fontSize="lg"
+              color="gray.800"
+              textAlign="left"
+              flex={1}
+              lineHeight="1.3"
+            >
+              {nursery.name}
+            </Text>
+          </HStack>
 
-        {/* 詳細情報部分: 見学日と質問進捗 */}
-        <VStack align="stretch" gap={2}>
-          <Text color="gray.600" fontSize="sm" textAlign="left">
-            見学日: {visitDate}
-          </Text>
-          <Text color="gray.600" fontSize="sm" textAlign="left">
-            質問進捗: {questionProgress}
-          </Text>
+          {/* 詳細情報部分: 見学日と質問進捗 */}
+          <VStack align="stretch" gap={2}>
+            <Text color="gray.600" fontSize="sm" textAlign="left">
+              見学日: {visitDate}
+            </Text>
+            <Text color="gray.600" fontSize="sm" textAlign="left">
+              質問進捗: {questionProgress}
+            </Text>
 
-          {/* 気づきタグ表示 */}
-          {insights.length > 0 && (
-            <Box>
-              <Flex wrap="wrap" gap={1} mt={1}>
-                {insights.map((insight, index) => (
-                  <InsightTag
-                    key={`insight-${index}`}
-                    text={insight}
-                    showDeleteButton={false}
-                    isReadOnly={true}
-                  />
-                ))}
-              </Flex>
-            </Box>
-          )}
+            {/* 気づきタグ表示 */}
+            {insights.length > 0 && (
+              <Box>
+                <Flex wrap="wrap" gap={1} mt={1}>
+                  {insights.map((insight, index) => (
+                    <InsightTag
+                      key={`insight-${index}`}
+                      text={insight}
+                      showDeleteButton={false}
+                      isReadOnly={true}
+                    />
+                  ))}
+                </Flex>
+              </Box>
+            )}
+          </VStack>
         </VStack>
-      </VStack>
+
+        {/* 右矢印アイコン */}
+        <Icon color="gray.400" size="md">
+          <IoChevronForward />
+        </Icon>
+      </HStack>
     </Box>
   );
 };

--- a/src/components/NurseryCard.tsx
+++ b/src/components/NurseryCard.tsx
@@ -102,7 +102,7 @@ export const NurseryCard = ({ nursery, onClick }: NurseryCardProps) => {
         </VStack>
 
         {/* 右矢印アイコン */}
-        <Icon color="gray.400" size="md">
+        <Icon color="gray.400" size="md" aria-hidden="true">
           <IoChevronForward />
         </Icon>
       </HStack>

--- a/src/components/NurseryCard.tsx
+++ b/src/components/NurseryCard.tsx
@@ -40,13 +40,6 @@ export const NurseryCard = ({ nursery, onClick }: NurseryCardProps) => {
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      handleInteraction();
-    }
-  };
-
   const { visitDate, questionProgress, insights } = useNurseryStatus(
     nursery.visitSessions
   );
@@ -55,7 +48,6 @@ export const NurseryCard = ({ nursery, onClick }: NurseryCardProps) => {
     <Box
       as="button"
       aria-label={`${nursery.name}の詳細を開く`}
-      tabIndex={0}
       p={4}
       borderWidth={1}
       borderRadius="md"
@@ -65,7 +57,6 @@ export const NurseryCard = ({ nursery, onClick }: NurseryCardProps) => {
       width="100%"
       cursor="pointer"
       onClick={handleInteraction}
-      onKeyDown={handleKeyDown}
     >
       <HStack align="center" gap={3} width="100%">
         <VStack align="stretch" gap={3} flex={1}>

--- a/src/components/NurseryCreator.integration.test.tsx
+++ b/src/components/NurseryCreator.integration.test.tsx
@@ -58,7 +58,9 @@ describe('NurseryCreator 統合テスト', () => {
     expect(nameInput).toHaveValue('テストデータ');
 
     // キャンセルボタンでフォームをリセット
-    const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+    const cancelButton = screen.getByRole('button', {
+      name: '保育園編集をキャンセル',
+    });
     await user.click(cancelButton);
 
     // onCancelが呼ばれることを確認（実際のアプリではフォームがクローズされる）
@@ -167,7 +169,9 @@ describe('NurseryCreator 統合テスト', () => {
 
     // ボタンのrole属性を確認
     const saveButton = screen.getByRole('button', { name: '保存' });
-    const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+    const cancelButton = screen.getByRole('button', {
+      name: '保育園編集をキャンセル',
+    });
 
     expect(saveButton).toBeInTheDocument();
     expect(cancelButton).toBeInTheDocument();

--- a/src/components/NurseryCreator.integration.test.tsx
+++ b/src/components/NurseryCreator.integration.test.tsx
@@ -58,9 +58,7 @@ describe('NurseryCreator 統合テスト', () => {
     expect(nameInput).toHaveValue('テストデータ');
 
     // キャンセルボタンでフォームをリセット
-    const cancelButton = screen.getByRole('button', {
-      name: '保育園編集をキャンセル',
-    });
+    const cancelButton = screen.getByText('キャンセル');
     await user.click(cancelButton);
 
     // onCancelが呼ばれることを確認（実際のアプリではフォームがクローズされる）
@@ -169,9 +167,7 @@ describe('NurseryCreator 統合テスト', () => {
 
     // ボタンのrole属性を確認
     const saveButton = screen.getByRole('button', { name: '保存' });
-    const cancelButton = screen.getByRole('button', {
-      name: '保育園編集をキャンセル',
-    });
+    const cancelButton = screen.getByText('キャンセル');
 
     expect(saveButton).toBeInTheDocument();
     expect(cancelButton).toBeInTheDocument();

--- a/src/components/NurseryCreator.test.tsx
+++ b/src/components/NurseryCreator.test.tsx
@@ -69,7 +69,7 @@ describe('NurseryCreator コンポーネント', () => {
 
       expect(screen.getByRole('button', { name: '保存' })).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: 'キャンセル' })
+        screen.getByRole('button', { name: '保育園編集をキャンセル' })
       ).toBeInTheDocument();
     });
   });
@@ -267,7 +267,9 @@ describe('NurseryCreator コンポーネント', () => {
       const mockOnCancel = vi.fn();
       renderWithProviders(<NurseryCreator onCancel={mockOnCancel} />);
 
-      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+      const cancelButton = screen.getByRole('button', {
+        name: '保育園編集をキャンセル',
+      });
       await user.click(cancelButton);
 
       expect(mockOnCancel).toHaveBeenCalled();
@@ -282,7 +284,9 @@ describe('NurseryCreator コンポーネント', () => {
       const nameInput = screen.getByLabelText('保育園名');
       await user.type(nameInput, '途中入力');
 
-      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+      const cancelButton = screen.getByRole('button', {
+        name: '保育園編集をキャンセル',
+      });
       await user.click(cancelButton);
 
       expect(mockOnCancel).toHaveBeenCalled();
@@ -316,7 +320,9 @@ describe('NurseryCreator コンポーネント', () => {
 
       renderWithProviders(<NurseryCreator onCancel={vi.fn()} />);
 
-      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+      const cancelButton = screen.getByRole('button', {
+        name: '保育園編集をキャンセル',
+      });
       expect(cancelButton).toBeEnabled();
     });
 
@@ -388,7 +394,9 @@ describe('NurseryCreator コンポーネント', () => {
       const nameInput = screen.getByLabelText('保育園名');
       const visitDateInput =
         screen.getByPlaceholderText('見学日を選択してください');
-      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+      const cancelButton = screen.getByRole('button', {
+        name: '保育園編集をキャンセル',
+      });
 
       // 最初の要素にフォーカス
       nameInput.focus();
@@ -612,7 +620,9 @@ describe('NurseryCreator コンポーネント', () => {
       expect(screen.getByLabelText('見学日')).toBeDisabled();
 
       // キャンセルボタンは有効のまま（UX改善）
-      expect(screen.getByRole('button', { name: 'キャンセル' })).toBeEnabled();
+      expect(
+        screen.getByRole('button', { name: '保育園編集をキャンセル' })
+      ).toBeEnabled();
 
       // ローディングメッセージが表示される
       expect(screen.getByText('保育園を作成中...')).toBeInTheDocument();

--- a/src/components/NurseryCreator.test.tsx
+++ b/src/components/NurseryCreator.test.tsx
@@ -68,9 +68,7 @@ describe('NurseryCreator コンポーネント', () => {
       renderWithProviders(<NurseryCreator onCancel={vi.fn()} />);
 
       expect(screen.getByRole('button', { name: '保存' })).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', { name: '保育園編集をキャンセル' })
-      ).toBeInTheDocument();
+      expect(screen.getByText('キャンセル')).toBeInTheDocument();
     });
   });
 
@@ -267,9 +265,7 @@ describe('NurseryCreator コンポーネント', () => {
       const mockOnCancel = vi.fn();
       renderWithProviders(<NurseryCreator onCancel={mockOnCancel} />);
 
-      const cancelButton = screen.getByRole('button', {
-        name: '保育園編集をキャンセル',
-      });
+      const cancelButton = screen.getByText('キャンセル');
       await user.click(cancelButton);
 
       expect(mockOnCancel).toHaveBeenCalled();
@@ -284,9 +280,7 @@ describe('NurseryCreator コンポーネント', () => {
       const nameInput = screen.getByLabelText('保育園名');
       await user.type(nameInput, '途中入力');
 
-      const cancelButton = screen.getByRole('button', {
-        name: '保育園編集をキャンセル',
-      });
+      const cancelButton = screen.getByText('キャンセル');
       await user.click(cancelButton);
 
       expect(mockOnCancel).toHaveBeenCalled();
@@ -320,9 +314,7 @@ describe('NurseryCreator コンポーネント', () => {
 
       renderWithProviders(<NurseryCreator onCancel={vi.fn()} />);
 
-      const cancelButton = screen.getByRole('button', {
-        name: '保育園編集をキャンセル',
-      });
+      const cancelButton = screen.getByText('キャンセル');
       expect(cancelButton).toBeEnabled();
     });
 
@@ -394,9 +386,7 @@ describe('NurseryCreator コンポーネント', () => {
       const nameInput = screen.getByLabelText('保育園名');
       const visitDateInput =
         screen.getByPlaceholderText('見学日を選択してください');
-      const cancelButton = screen.getByRole('button', {
-        name: '保育園編集をキャンセル',
-      });
+      const cancelButton = screen.getByText('キャンセル');
 
       // 最初の要素にフォーカス
       nameInput.focus();
@@ -620,9 +610,7 @@ describe('NurseryCreator コンポーネント', () => {
       expect(screen.getByLabelText('見学日')).toBeDisabled();
 
       // キャンセルボタンは有効のまま（UX改善）
-      expect(
-        screen.getByRole('button', { name: '保育園編集をキャンセル' })
-      ).toBeEnabled();
+      expect(screen.getByText('キャンセル')).toBeEnabled();
 
       // ローディングメッセージが表示される
       expect(screen.getByText('保育園を作成中...')).toBeInTheDocument();

--- a/src/components/NurseryCreator/FormActions.test.tsx
+++ b/src/components/NurseryCreator/FormActions.test.tsx
@@ -113,6 +113,36 @@ describe('FormActionsコンポーネント群', () => {
       expect(saveButton).toHaveAttribute('data-size', 'lg');
       expect(cancelButton).toHaveAttribute('data-size', 'lg');
     });
+
+    it('cancelContextが指定されていない場合はcancelLabelのみがaria-labelに設定される', () => {
+      renderWithProviders(
+        <PrimaryFormActions
+          onSave={mockOnSave}
+          onCancel={mockOnCancel}
+          cancelLabel="戻る"
+        />
+      );
+
+      const cancelButton = screen.getByRole('button', { name: '戻る' });
+      expect(cancelButton).toBeInTheDocument();
+    });
+
+    it('cancelContextが指定されている場合は組み合わせたaria-labelが設定される', () => {
+      renderWithProviders(
+        <PrimaryFormActions
+          onSave={mockOnSave}
+          onCancel={mockOnCancel}
+          cancelLabel="戻る"
+          cancelContext="保育園編集をキャンセル"
+        />
+      );
+
+      const cancelButton = screen.getByRole('button', {
+        name: '戻る（保育園編集をキャンセル）',
+      });
+      expect(cancelButton).toBeInTheDocument();
+      expect(cancelButton).toHaveTextContent('戻る');
+    });
   });
 
   describe('InlineFormActions', () => {
@@ -178,6 +208,23 @@ describe('FormActionsコンポーネント群', () => {
       expect(saveButton).toHaveAttribute('data-size', 'sm');
       expect(cancelButton).toHaveAttribute('data-size', 'sm');
     });
+
+    it('cancelContextが指定されている場合は組み合わせたaria-labelが設定される', () => {
+      renderWithProviders(
+        <InlineFormActions
+          onSave={mockOnSave}
+          onCancel={mockOnCancel}
+          cancelLabel="戻る"
+          cancelContext="保育園編集をキャンセル"
+        />
+      );
+
+      const cancelButton = screen.getByRole('button', {
+        name: '戻る（保育園編集をキャンセル）',
+      });
+      expect(cancelButton).toBeInTheDocument();
+      expect(cancelButton).toHaveTextContent('戻る');
+    });
   });
 
   describe('VerticalFormActions', () => {
@@ -242,6 +289,23 @@ describe('FormActionsコンポーネント群', () => {
       const cancelButton = screen.getByText('キャンセル');
       expect(saveButton).toHaveAttribute('data-size', 'lg');
       expect(cancelButton).toHaveAttribute('data-size', 'lg');
+    });
+
+    it('cancelContextが指定されている場合は組み合わせたaria-labelが設定される', () => {
+      renderWithProviders(
+        <VerticalFormActions
+          onSave={mockOnSave}
+          onCancel={mockOnCancel}
+          cancelLabel="戻る"
+          cancelContext="保育園編集をキャンセル"
+        />
+      );
+
+      const cancelButton = screen.getByRole('button', {
+        name: '戻る（保育園編集をキャンセル）',
+      });
+      expect(cancelButton).toBeInTheDocument();
+      expect(cancelButton).toHaveTextContent('戻る');
     });
   });
 });

--- a/src/components/NurseryCreator/FormActions.test.tsx
+++ b/src/components/NurseryCreator/FormActions.test.tsx
@@ -52,9 +52,7 @@ describe('FormActionsコンポーネント群', () => {
         <PrimaryFormActions onSave={mockOnSave} onCancel={mockOnCancel} />
       );
 
-      await user.click(
-        screen.getByRole('button', { name: '保育園編集をキャンセル' })
-      );
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }));
       expect(mockOnCancel).toHaveBeenCalledTimes(1);
     });
 
@@ -71,7 +69,7 @@ describe('FormActionsコンポーネント群', () => {
       expect(saveButton).toBeDisabled();
 
       const cancelButton = screen.getByRole('button', {
-        name: '保育園編集をキャンセル',
+        name: 'キャンセル',
       });
       expect(cancelButton).not.toBeDisabled();
     });
@@ -148,9 +146,7 @@ describe('FormActionsコンポーネント群', () => {
         <InlineFormActions onSave={mockOnSave} onCancel={mockOnCancel} />
       );
 
-      await user.click(
-        screen.getByRole('button', { name: '保育園編集をキャンセル' })
-      );
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }));
       expect(mockOnCancel).toHaveBeenCalledTimes(1);
     });
 
@@ -167,7 +163,7 @@ describe('FormActionsコンポーネント群', () => {
       expect(saveButton).toBeDisabled();
 
       const cancelButton = screen.getByRole('button', {
-        name: '保育園編集をキャンセル',
+        name: 'キャンセル',
       });
       expect(cancelButton).not.toBeDisabled();
     });
@@ -215,9 +211,7 @@ describe('FormActionsコンポーネント群', () => {
         <VerticalFormActions onSave={mockOnSave} onCancel={mockOnCancel} />
       );
 
-      await user.click(
-        screen.getByRole('button', { name: '保育園編集をキャンセル' })
-      );
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }));
       expect(mockOnCancel).toHaveBeenCalledTimes(1);
     });
 
@@ -234,7 +228,7 @@ describe('FormActionsコンポーネント群', () => {
       expect(saveButton).toBeDisabled();
 
       const cancelButton = screen.getByRole('button', {
-        name: '保育園編集をキャンセル',
+        name: 'キャンセル',
       });
       expect(cancelButton).not.toBeDisabled();
     });

--- a/src/components/NurseryCreator/FormActions.test.tsx
+++ b/src/components/NurseryCreator/FormActions.test.tsx
@@ -52,7 +52,9 @@ describe('FormActionsコンポーネント群', () => {
         <PrimaryFormActions onSave={mockOnSave} onCancel={mockOnCancel} />
       );
 
-      await user.click(screen.getByText('キャンセル'));
+      await user.click(
+        screen.getByRole('button', { name: '保育園編集をキャンセル' })
+      );
       expect(mockOnCancel).toHaveBeenCalledTimes(1);
     });
 
@@ -68,7 +70,9 @@ describe('FormActionsコンポーネント群', () => {
       const saveButton = screen.getByText('保存');
       expect(saveButton).toBeDisabled();
 
-      const cancelButton = screen.getByText('キャンセル');
+      const cancelButton = screen.getByRole('button', {
+        name: '保育園編集をキャンセル',
+      });
       expect(cancelButton).not.toBeDisabled();
     });
 
@@ -144,7 +148,9 @@ describe('FormActionsコンポーネント群', () => {
         <InlineFormActions onSave={mockOnSave} onCancel={mockOnCancel} />
       );
 
-      await user.click(screen.getByText('キャンセル'));
+      await user.click(
+        screen.getByRole('button', { name: '保育園編集をキャンセル' })
+      );
       expect(mockOnCancel).toHaveBeenCalledTimes(1);
     });
 
@@ -160,7 +166,9 @@ describe('FormActionsコンポーネント群', () => {
       const saveButton = screen.getByText('保存');
       expect(saveButton).toBeDisabled();
 
-      const cancelButton = screen.getByText('キャンセル');
+      const cancelButton = screen.getByRole('button', {
+        name: '保育園編集をキャンセル',
+      });
       expect(cancelButton).not.toBeDisabled();
     });
 
@@ -207,7 +215,9 @@ describe('FormActionsコンポーネント群', () => {
         <VerticalFormActions onSave={mockOnSave} onCancel={mockOnCancel} />
       );
 
-      await user.click(screen.getByText('キャンセル'));
+      await user.click(
+        screen.getByRole('button', { name: '保育園編集をキャンセル' })
+      );
       expect(mockOnCancel).toHaveBeenCalledTimes(1);
     });
 
@@ -223,7 +233,9 @@ describe('FormActionsコンポーネント群', () => {
       const saveButton = screen.getByText('保存');
       expect(saveButton).toBeDisabled();
 
-      const cancelButton = screen.getByText('キャンセル');
+      const cancelButton = screen.getByRole('button', {
+        name: '保育園編集をキャンセル',
+      });
       expect(cancelButton).not.toBeDisabled();
     });
 

--- a/src/components/NurseryCreator/FormActions.tsx
+++ b/src/components/NurseryCreator/FormActions.tsx
@@ -50,6 +50,7 @@ export const PrimaryFormActions = ({
         variant="subtle"
         size={size}
         data-size={size}
+        aria-label="保育園編集をキャンセル"
         flex={1}
         {...primaryCancelButtonStyles}
       >
@@ -138,6 +139,7 @@ export const VerticalFormActions = ({
         variant="subtle"
         size={size}
         data-size={size}
+        aria-label="保育園編集をキャンセル"
         {...primaryCancelButtonStyles}
         w="full"
         py={3} // 縦並びでは異なるパディングを維持

--- a/src/components/NurseryCreator/FormActions.tsx
+++ b/src/components/NurseryCreator/FormActions.tsx
@@ -89,6 +89,7 @@ export const InlineFormActions = ({
         variant="subtle"
         size={size}
         data-size={size}
+        aria-label="保育園編集をキャンセル"
         {...commonButtonStyles}
       >
         {cancelLabel}

--- a/src/components/NurseryCreator/FormActions.tsx
+++ b/src/components/NurseryCreator/FormActions.tsx
@@ -28,6 +28,7 @@ interface FormActionsProps {
   isDisabled?: boolean;
   saveLabel?: string;
   cancelLabel?: string;
+  cancelContext?: string;
   size?: ButtonProps['size'];
 }
 
@@ -40,6 +41,7 @@ export const PrimaryFormActions = ({
   isDisabled = false,
   saveLabel = '保存',
   cancelLabel = 'キャンセル',
+  cancelContext,
   size = 'lg',
 }: FormActionsProps) => {
   return (
@@ -50,7 +52,9 @@ export const PrimaryFormActions = ({
         variant="subtle"
         size={size}
         data-size={size}
-        aria-label="保育園編集をキャンセル"
+        aria-label={
+          cancelContext ? `${cancelLabel}（${cancelContext}）` : cancelLabel
+        }
         flex={1}
         {...primaryCancelButtonStyles}
       >
@@ -80,6 +84,7 @@ export const InlineFormActions = ({
   isDisabled = false,
   saveLabel = '保存',
   cancelLabel = 'キャンセル',
+  cancelContext,
   size = 'sm',
 }: FormActionsProps) => {
   return (
@@ -90,7 +95,9 @@ export const InlineFormActions = ({
         variant="subtle"
         size={size}
         data-size={size}
-        aria-label="保育園編集をキャンセル"
+        aria-label={
+          cancelContext ? `${cancelLabel}（${cancelContext}）` : cancelLabel
+        }
         {...commonButtonStyles}
       >
         {cancelLabel}
@@ -118,6 +125,7 @@ export const VerticalFormActions = ({
   isDisabled = false,
   saveLabel = '保存',
   cancelLabel = 'キャンセル',
+  cancelContext,
   size = 'lg',
 }: FormActionsProps) => {
   return (
@@ -139,7 +147,9 @@ export const VerticalFormActions = ({
         variant="subtle"
         size={size}
         data-size={size}
-        aria-label="保育園編集をキャンセル"
+        aria-label={
+          cancelContext ? `${cancelLabel}（${cancelContext}）` : cancelLabel
+        }
         {...primaryCancelButtonStyles}
         w="full"
         py={3} // 縦並びでは異なるパディングを維持

--- a/src/components/QuestionAddForm.test.tsx
+++ b/src/components/QuestionAddForm.test.tsx
@@ -10,10 +10,8 @@ import { QuestionAddForm } from './QuestionAddForm';
 
 describe('QuestionAddForm', () => {
   const defaultProps = {
-    isAddingQuestion: false,
     newQuestionText: '',
     newAnswerText: '',
-    onToggleAddForm: vi.fn<(value: boolean) => void>(),
     onNewQuestionTextChange: vi.fn<(value: string) => void>(),
     onNewAnswerTextChange: vi.fn<(value: string) => void>(),
     onAddQuestion: vi.fn<() => void>(),
@@ -23,54 +21,23 @@ describe('QuestionAddForm', () => {
     vi.clearAllMocks();
   });
 
-  describe('フォーム非表示状態', () => {
-    test('「+ 質問を追加」ボタンが表示される', () => {
-      renderWithProviders(<QuestionAddForm {...defaultProps} />);
-
-      const addButton = screen.getByRole('button', { name: '+ 質問を追加' });
-      expect(addButton).toBeInTheDocument();
-    });
-
-    test('ボタンをクリックするとonToggleAddFormが呼ばれる', async () => {
-      const user = userEvent.setup();
-      const mockOnToggleAddForm = vi.fn();
-
-      renderWithProviders(
-        <QuestionAddForm
-          {...defaultProps}
-          onToggleAddForm={mockOnToggleAddForm}
-        />
-      );
-
-      const addButton = screen.getByRole('button', { name: '+ 質問を追加' });
-      await user.click(addButton);
-
-      expect(mockOnToggleAddForm).toHaveBeenCalledWith(true);
-    });
-  });
-
-  describe('フォーム表示状態', () => {
-    const openFormProps = {
-      ...defaultProps,
-      isAddingQuestion: true,
-    };
-
+  describe('フォーム表示', () => {
     test('質問入力フィールドが表示される', () => {
-      renderWithProviders(<QuestionAddForm {...openFormProps} />);
+      renderWithProviders(<QuestionAddForm {...defaultProps} />);
 
       const input = screen.getByLabelText('質問入力');
       expect(input).toBeInTheDocument();
     });
 
     test('回答入力フィールドが表示される', () => {
-      renderWithProviders(<QuestionAddForm {...openFormProps} />);
+      renderWithProviders(<QuestionAddForm {...defaultProps} />);
 
       const textarea = screen.getByLabelText('回答入力（任意）');
       expect(textarea).toBeInTheDocument();
     });
 
     test('追加ボタンとキャンセルボタンが表示される', () => {
-      renderWithProviders(<QuestionAddForm {...openFormProps} />);
+      renderWithProviders(<QuestionAddForm {...defaultProps} />);
 
       expect(screen.getByRole('button', { name: '追加' })).toBeInTheDocument();
       expect(
@@ -84,7 +51,7 @@ describe('QuestionAddForm', () => {
 
       renderWithProviders(
         <QuestionAddForm
-          {...openFormProps}
+          {...defaultProps}
           onNewQuestionTextChange={mockOnChange}
         />
       );
@@ -104,7 +71,7 @@ describe('QuestionAddForm', () => {
 
       renderWithProviders(
         <QuestionAddForm
-          {...openFormProps}
+          {...defaultProps}
           onNewAnswerTextChange={mockOnAnswerChange}
         />
       );
@@ -122,7 +89,7 @@ describe('QuestionAddForm', () => {
 
       renderWithProviders(
         <QuestionAddForm
-          {...openFormProps}
+          {...defaultProps}
           newQuestionText="延長保育はありますか？"
           onAddQuestion={mockOnAddQuestion}
         />
@@ -134,23 +101,6 @@ describe('QuestionAddForm', () => {
       expect(mockOnAddQuestion).toHaveBeenCalled();
     });
 
-    test('キャンセルボタンをクリックするとonToggleAddFormが呼ばれる', async () => {
-      const user = userEvent.setup();
-      const mockOnToggleAddForm = vi.fn();
-
-      renderWithProviders(
-        <QuestionAddForm
-          {...openFormProps}
-          onToggleAddForm={mockOnToggleAddForm}
-        />
-      );
-
-      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
-      await user.click(cancelButton);
-
-      expect(mockOnToggleAddForm).toHaveBeenCalledWith(false);
-    });
-
     test('キャンセルボタンをクリックすると入力値がクリアされる', async () => {
       const user = userEvent.setup();
       const mockOnQuestionChange = vi.fn();
@@ -158,7 +108,7 @@ describe('QuestionAddForm', () => {
 
       renderWithProviders(
         <QuestionAddForm
-          {...openFormProps}
+          {...defaultProps}
           newQuestionText="テスト質問"
           newAnswerText="テスト回答"
           onNewQuestionTextChange={mockOnQuestionChange}
@@ -175,7 +125,7 @@ describe('QuestionAddForm', () => {
 
     test('質問が空の場合、追加ボタンが無効化される', () => {
       renderWithProviders(
-        <QuestionAddForm {...openFormProps} newQuestionText="" />
+        <QuestionAddForm {...defaultProps} newQuestionText="" />
       );
 
       const addButton = screen.getByRole('button', { name: '追加' });
@@ -184,7 +134,7 @@ describe('QuestionAddForm', () => {
 
     test('質問が空白のみの場合、追加ボタンが無効化される', () => {
       renderWithProviders(
-        <QuestionAddForm {...openFormProps} newQuestionText="   " />
+        <QuestionAddForm {...defaultProps} newQuestionText="   " />
       );
 
       const addButton = screen.getByRole('button', { name: '追加' });
@@ -194,7 +144,7 @@ describe('QuestionAddForm', () => {
     test('質問が入力されている場合、追加ボタンが有効になる', () => {
       renderWithProviders(
         <QuestionAddForm
-          {...openFormProps}
+          {...defaultProps}
           newQuestionText="延長保育はありますか？"
         />
       );
@@ -207,11 +157,7 @@ describe('QuestionAddForm', () => {
   describe('値の表示', () => {
     test('既存の質問テキストが入力フィールドに表示される', () => {
       renderWithProviders(
-        <QuestionAddForm
-          {...defaultProps}
-          isAddingQuestion={true}
-          newQuestionText="既存の質問"
-        />
+        <QuestionAddForm {...defaultProps} newQuestionText="既存の質問" />
       );
 
       const input = screen.getByLabelText('質問入力');
@@ -220,11 +166,7 @@ describe('QuestionAddForm', () => {
 
     test('既存の回答テキストが回答フィールドに表示される', () => {
       renderWithProviders(
-        <QuestionAddForm
-          {...defaultProps}
-          isAddingQuestion={true}
-          newAnswerText="既存の回答"
-        />
+        <QuestionAddForm {...defaultProps} newAnswerText="既存の回答" />
       );
 
       const textarea = screen.getByLabelText('回答入力（任意）');
@@ -235,7 +177,6 @@ describe('QuestionAddForm', () => {
       renderWithProviders(
         <QuestionAddForm
           {...defaultProps}
-          isAddingQuestion={true}
           newQuestionText=""
           newAnswerText="回答だけがある"
         />
@@ -249,7 +190,6 @@ describe('QuestionAddForm', () => {
       renderWithProviders(
         <QuestionAddForm
           {...defaultProps}
-          isAddingQuestion={true}
           newQuestionText="質問"
           newAnswerText="回答"
         />

--- a/src/components/QuestionAddForm.test.tsx
+++ b/src/components/QuestionAddForm.test.tsx
@@ -41,7 +41,7 @@ describe('QuestionAddForm', () => {
 
       expect(screen.getByRole('button', { name: '追加' })).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: 'キャンセル' })
+        screen.getByRole('button', { name: '質問追加をキャンセル' })
       ).toBeInTheDocument();
     });
 
@@ -116,7 +116,9 @@ describe('QuestionAddForm', () => {
         />
       );
 
-      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+      const cancelButton = screen.getByRole('button', {
+        name: '質問追加をキャンセル',
+      });
       await user.click(cancelButton);
 
       expect(mockOnQuestionChange).toHaveBeenCalledWith('');

--- a/src/components/QuestionAddForm.tsx
+++ b/src/components/QuestionAddForm.tsx
@@ -2,31 +2,20 @@
  * 質問追加フォームコンポーネント
  */
 
-import {
-  Button,
-  Input,
-  Textarea,
-  VStack,
-  HStack,
-  Text,
-} from '@chakra-ui/react';
+import { Button, Input, Textarea, VStack, HStack } from '@chakra-ui/react';
 import { useCallback } from 'react';
 
 interface QuestionAddFormProps {
-  isAddingQuestion: boolean;
   newQuestionText: string;
   newAnswerText: string;
-  onToggleAddForm: (value: boolean) => void;
   onNewQuestionTextChange: (value: string) => void;
   onNewAnswerTextChange: (value: string) => void;
   onAddQuestion: () => void;
 }
 
 export const QuestionAddForm = ({
-  isAddingQuestion,
   newQuestionText,
   newAnswerText,
-  onToggleAddForm,
   onNewQuestionTextChange,
   onNewAnswerTextChange,
   onAddQuestion,
@@ -34,69 +23,47 @@ export const QuestionAddForm = ({
   const handleCancel = useCallback(() => {
     onNewQuestionTextChange('');
     onNewAnswerTextChange('');
-    onToggleAddForm(false);
-  }, [onNewQuestionTextChange, onNewAnswerTextChange, onToggleAddForm]);
-
-  const handleStartAdding = useCallback(() => {
-    onToggleAddForm(true);
-  }, [onToggleAddForm]);
-  if (isAddingQuestion) {
-    return (
-      <VStack align="stretch">
-        <Input
-          size="lg"
-          placeholder="新しい質問を入力してください"
-          aria-label="質問入力"
-          autoFocus
-          value={newQuestionText}
-          onChange={(e) => onNewQuestionTextChange(e.target.value)}
-          bg="white"
-        />
-        <Textarea
-          size="lg"
-          placeholder="回答があれば入力してください（任意）"
-          aria-label="回答入力（任意）"
-          value={newAnswerText}
-          onChange={(e) => onNewAnswerTextChange(e.target.value)}
-          bg="white"
-          rows={3}
-          resize="vertical"
-        />
-        <HStack justify="flex-end" gap={2}>
-          <Button
-            colorPalette="brand"
-            variant="subtle"
-            onClick={handleCancel}
-            size={{ base: 'sm', md: 'md' }}
-          >
-            キャンセル
-          </Button>
-          <Button
-            colorPalette="brand"
-            variant="solid"
-            onClick={onAddQuestion}
-            disabled={!newQuestionText.trim()}
-            size={{ base: 'sm', md: 'md' }}
-          >
-            追加
-          </Button>
-        </HStack>
-      </VStack>
-    );
-  }
+  }, [onNewQuestionTextChange, onNewAnswerTextChange]);
 
   return (
-    <Button
-      colorPalette="brand"
-      variant="solid"
-      onClick={handleStartAdding}
-      size={{ base: 'md', md: 'lg' }}
-      w="full"
-    >
-      <Text fontSize="lg" mr={2}>
-        +
-      </Text>
-      質問を追加
-    </Button>
+    <VStack align="stretch">
+      <Input
+        size="lg"
+        placeholder="新しい質問を入力してください"
+        aria-label="質問入力"
+        value={newQuestionText}
+        onChange={(e) => onNewQuestionTextChange(e.target.value)}
+        bg="white"
+      />
+      <Textarea
+        size="lg"
+        placeholder="回答があれば入力してください（任意）"
+        aria-label="回答入力（任意）"
+        value={newAnswerText}
+        onChange={(e) => onNewAnswerTextChange(e.target.value)}
+        bg="white"
+        rows={3}
+        resize="vertical"
+      />
+      <HStack justify="flex-end" gap={2}>
+        <Button
+          colorPalette="brand"
+          variant="subtle"
+          onClick={handleCancel}
+          size={{ base: 'sm', md: 'md' }}
+        >
+          キャンセル
+        </Button>
+        <Button
+          colorPalette="brand"
+          variant="solid"
+          onClick={onAddQuestion}
+          disabled={!newQuestionText.trim()}
+          size={{ base: 'sm', md: 'md' }}
+        >
+          追加
+        </Button>
+      </HStack>
+    </VStack>
   );
 };

--- a/src/components/QuestionAddForm.tsx
+++ b/src/components/QuestionAddForm.tsx
@@ -51,6 +51,7 @@ export const QuestionAddForm = ({
           variant="subtle"
           onClick={handleCancel}
           size={{ base: 'sm', md: 'md' }}
+          aria-label="質問追加をキャンセル"
         >
           キャンセル
         </Button>

--- a/src/hooks/useQuestionForm.test.ts
+++ b/src/hooks/useQuestionForm.test.ts
@@ -7,46 +7,12 @@ import { describe, test, expect } from 'vitest';
 import { useQuestionForm } from './useQuestionForm';
 
 describe('useQuestionForm', () => {
-  test('初期状態は追加モードではない', () => {
+  test('初期状態は質問と回答が空で無効', () => {
     const { result } = renderHook(() => useQuestionForm());
 
-    expect(result.current.formState.isAdding).toBe(false);
     expect(result.current.formState.questionText).toBe('');
     expect(result.current.formState.answerText).toBe('');
     expect(result.current.isValid).toBe(false);
-  });
-
-  test('startAddingで追加モードに移行する', () => {
-    const { result } = renderHook(() => useQuestionForm());
-
-    act(() => {
-      result.current.startAdding();
-    });
-
-    expect(result.current.formState.isAdding).toBe(true);
-    expect(result.current.formState.questionText).toBe('');
-    expect(result.current.formState.answerText).toBe('');
-  });
-
-  test('startAddingは既存の入力値を保持する', () => {
-    const { result } = renderHook(() => useQuestionForm());
-
-    // 先に入力値を設定
-    act(() => {
-      result.current.updateQuestionText('下書きの質問');
-      result.current.updateAnswerText('下書きの回答');
-    });
-
-    // startAddingを実行
-    act(() => {
-      result.current.startAdding();
-    });
-
-    // 入力値が保持されることを確認
-    expect(result.current.formState.isAdding).toBe(true);
-    expect(result.current.formState.questionText).toBe('下書きの質問');
-    expect(result.current.formState.answerText).toBe('下書きの回答');
-    expect(result.current.isValid).toBe(true);
   });
 
   test('updateQuestionTextで質問テキストが更新される', () => {
@@ -70,112 +36,63 @@ describe('useQuestionForm', () => {
 
     expect(result.current.formState.questionText).toBe('');
     expect(result.current.formState.answerText).toBe('新しい回答');
-    expect(result.current.isValid).toBe(false); // 質問が空なのでinvalid
+    expect(result.current.isValid).toBe(false); // 質問が空なので無効
   });
 
-  test('質問テキストが空文字の場合はinvalid', () => {
+  test('質問テキストと回答テキストの両方が設定される', () => {
     const { result } = renderHook(() => useQuestionForm());
 
     act(() => {
-      result.current.updateQuestionText('');
-      result.current.updateAnswerText('回答がある');
-    });
-
-    expect(result.current.isValid).toBe(false);
-  });
-
-  test('質問テキストが空白のみの場合はinvalid', () => {
-    const { result } = renderHook(() => useQuestionForm());
-
-    act(() => {
-      result.current.updateQuestionText('   ');
-      result.current.updateAnswerText('回答がある');
-    });
-
-    expect(result.current.isValid).toBe(false);
-  });
-
-  test('質問テキストがある場合はvalid（回答は任意）', () => {
-    const { result } = renderHook(() => useQuestionForm());
-
-    act(() => {
-      result.current.updateQuestionText('質問がある');
-    });
-
-    expect(result.current.isValid).toBe(true);
-
-    act(() => {
-      result.current.updateAnswerText('回答も追加');
-    });
-
-    expect(result.current.isValid).toBe(true);
-  });
-
-  test('resetFormで初期状態に戻る', () => {
-    const { result } = renderHook(() => useQuestionForm());
-
-    act(() => {
-      result.current.startAdding();
       result.current.updateQuestionText('質問');
       result.current.updateAnswerText('回答');
     });
 
-    expect(result.current.formState.isAdding).toBe(true);
+    expect(result.current.formState.questionText).toBe('質問');
+    expect(result.current.formState.answerText).toBe('回答');
+    expect(result.current.isValid).toBe(true);
+  });
+
+  test('質問テキストが空白のみの場合は無効', () => {
+    const { result } = renderHook(() => useQuestionForm());
+
+    act(() => {
+      result.current.updateQuestionText('   ');
+    });
+
+    expect(result.current.formState.questionText).toBe('   ');
+    expect(result.current.isValid).toBe(false);
+  });
+
+  test('resetFormで全ての値がリセットされる', () => {
+    const { result } = renderHook(() => useQuestionForm());
+
+    act(() => {
+      result.current.updateQuestionText('質問');
+      result.current.updateAnswerText('回答');
+    });
+
+    expect(result.current.formState.questionText).toBe('質問');
+    expect(result.current.formState.answerText).toBe('回答');
     expect(result.current.isValid).toBe(true);
 
     act(() => {
       result.current.resetForm();
     });
 
-    expect(result.current.formState.isAdding).toBe(false);
     expect(result.current.formState.questionText).toBe('');
     expect(result.current.formState.answerText).toBe('');
     expect(result.current.isValid).toBe(false);
   });
 
-  test('cancelAddingで初期状態に戻る', () => {
+  test('質問テキストのみでフォームが有効になる', () => {
     const { result } = renderHook(() => useQuestionForm());
 
     act(() => {
-      result.current.startAdding();
-      result.current.updateQuestionText('質問');
-      result.current.updateAnswerText('回答');
+      result.current.updateQuestionText('質問のみ');
     });
 
-    act(() => {
-      result.current.cancelAdding();
-    });
-
-    expect(result.current.formState.isAdding).toBe(false);
-    expect(result.current.formState.questionText).toBe('');
+    expect(result.current.formState.questionText).toBe('質問のみ');
     expect(result.current.formState.answerText).toBe('');
-    expect(result.current.isValid).toBe(false);
-  });
-
-  test('複数回の更新が正しく動作する', () => {
-    const { result } = renderHook(() => useQuestionForm());
-
-    act(() => {
-      result.current.updateQuestionText('質問1');
-    });
-
-    expect(result.current.isValid).toBe(true);
-
-    act(() => {
-      result.current.updateQuestionText('質問2');
-      result.current.updateAnswerText('回答1');
-    });
-
-    expect(result.current.formState.questionText).toBe('質問2');
-    expect(result.current.formState.answerText).toBe('回答1');
-    expect(result.current.isValid).toBe(true);
-
-    act(() => {
-      result.current.updateAnswerText('回答2');
-    });
-
-    expect(result.current.formState.questionText).toBe('質問2');
-    expect(result.current.formState.answerText).toBe('回答2');
     expect(result.current.isValid).toBe(true);
   });
 });

--- a/src/hooks/useQuestionForm.ts
+++ b/src/hooks/useQuestionForm.ts
@@ -5,23 +5,17 @@
 import { useState, useCallback } from 'react';
 
 interface QuestionFormState {
-  isAdding: boolean;
   questionText: string;
   answerText: string;
 }
 
 const initialState: QuestionFormState = {
-  isAdding: false,
   questionText: '',
   answerText: '',
 };
 
 export const useQuestionForm = () => {
   const [formState, setFormState] = useState<QuestionFormState>(initialState);
-
-  const startAdding = useCallback(() => {
-    setFormState((prev) => ({ ...prev, isAdding: true }));
-  }, []);
 
   const updateQuestionText = useCallback((questionText: string) => {
     setFormState((prev) => ({ ...prev, questionText }));
@@ -35,19 +29,13 @@ export const useQuestionForm = () => {
     setFormState(() => ({ ...initialState }));
   }, []);
 
-  const cancelAdding = useCallback(() => {
-    setFormState(() => ({ ...initialState }));
-  }, []);
-
   const isValid = formState.questionText.trim() !== '';
 
   return {
     formState,
     isValid,
-    startAdding,
     updateQuestionText,
     updateAnswerText,
     resetForm,
-    cancelAdding,
   };
 };

--- a/src/pages/NurseryDetailPage.deletion.test.tsx
+++ b/src/pages/NurseryDetailPage.deletion.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '../test/test-utils';
 import { NurseryDetailPage } from './NurseryDetailPage';
@@ -145,7 +145,11 @@ describe('NurseryDetailPage - 削除機能', () => {
       expect(screen.getByText('保育園の削除')).toBeInTheDocument();
     });
 
-    const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+    // 削除ダイアログ内のキャンセルボタンを取得
+    const dialog = screen.getByRole('dialog', { name: '保育園の削除' });
+    const cancelButton = within(dialog).getByRole('button', {
+      name: 'キャンセル',
+    });
     await user.click(cancelButton);
 
     await waitFor(() => {

--- a/src/pages/NurseryDetailPage.test.tsx
+++ b/src/pages/NurseryDetailPage.test.tsx
@@ -213,12 +213,15 @@ describe('NurseryDetailPage コンポーネント', () => {
 
       // 編集用のUI要素が表示される（詳細テストはNurseryInfoCardで実施）
       const saveButton = screen.getByRole('button', { name: '保存' });
-      const cancelButtons = screen.getAllByRole('button', {
-        name: 'キャンセル',
+      const nurseryCancelButton = screen.getByRole('button', {
+        name: '保育園編集をキャンセル',
+      });
+      const questionCancelButton = screen.getByRole('button', {
+        name: '質問追加をキャンセル',
       });
       expect(saveButton).toBeInTheDocument();
-      // 保育園編集用と質問追加フォーム用の2つのキャンセルボタンが存在
-      expect(cancelButtons).toHaveLength(2);
+      expect(nurseryCancelButton).toBeInTheDocument();
+      expect(questionCancelButton).toBeInTheDocument();
     });
   });
 

--- a/src/pages/NurseryDetailPage.test.tsx
+++ b/src/pages/NurseryDetailPage.test.tsx
@@ -124,9 +124,7 @@ describe('NurseryDetailPage コンポーネント', () => {
       expect(screen.getByText(/質問進捗:/)).toBeInTheDocument();
 
       // QuestionsSection、QuestionAddForm、InsightsSectionの存在確認
-      expect(
-        screen.getByRole('button', { name: '+ 質問を追加' })
-      ).toBeInTheDocument();
+      expect(screen.getByLabelText('質問入力')).toBeInTheDocument();
       expect(
         screen.getByText('保育時間は何時から何時までですか？')
       ).toBeInTheDocument();
@@ -199,8 +197,8 @@ describe('NurseryDetailPage コンポーネント', () => {
       renderWithProviders(<NurseryDetailPage />);
 
       // 質問追加フォームが表示されることを確認（詳細動作はQuestionAddFormでテスト）
-      const addButton = screen.getByRole('button', { name: '+ 質問を追加' });
-      expect(addButton).toBeInTheDocument();
+      const questionInput = screen.getByLabelText('質問入力');
+      expect(questionInput).toBeInTheDocument();
     });
   });
 
@@ -215,9 +213,12 @@ describe('NurseryDetailPage コンポーネント', () => {
 
       // 編集用のUI要素が表示される（詳細テストはNurseryInfoCardで実施）
       const saveButton = screen.getByRole('button', { name: '保存' });
-      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+      const cancelButtons = screen.getAllByRole('button', {
+        name: 'キャンセル',
+      });
       expect(saveButton).toBeInTheDocument();
-      expect(cancelButton).toBeInTheDocument();
+      // 保育園編集用と質問追加フォーム用の2つのキャンセルボタンが存在
+      expect(cancelButtons).toHaveLength(2);
     });
   });
 
@@ -283,11 +284,9 @@ describe('NurseryDetailPage コンポーネント', () => {
       editButton.focus();
       expect(editButton).toHaveFocus();
 
-      const addQuestionButton = screen.getByRole('button', {
-        name: '+ 質問を追加',
-      });
-      addQuestionButton.focus();
-      expect(addQuestionButton).toHaveFocus();
+      const questionInput = screen.getByLabelText('質問入力');
+      questionInput.focus();
+      expect(questionInput).toHaveFocus();
     });
 
     test('スクリーンリーダー向けの適切なラベルが設定されている', () => {
@@ -358,9 +357,7 @@ describe('NurseryDetailPage コンポーネント', () => {
       ).toBeInTheDocument();
 
       // エラー時は主要コンポーネントが表示されないことを確認
-      expect(
-        screen.queryByRole('button', { name: '+ 質問を追加' })
-      ).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('質問入力')).not.toBeInTheDocument();
     });
 
     test('ローディング状態が全体に適切に反映される', () => {
@@ -384,9 +381,7 @@ describe('NurseryDetailPage コンポーネント', () => {
       ).toBeInTheDocument();
 
       // ローディング時は主要コンポーネントが表示されないことを確認
-      expect(
-        screen.queryByRole('button', { name: '+ 質問を追加' })
-      ).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('質問入力')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/pages/NurseryDetailPage.test.tsx
+++ b/src/pages/NurseryDetailPage.test.tsx
@@ -213,9 +213,7 @@ describe('NurseryDetailPage コンポーネント', () => {
 
       // 編集用のUI要素が表示される（詳細テストはNurseryInfoCardで実施）
       const saveButton = screen.getByRole('button', { name: '保存' });
-      const nurseryCancelButton = screen.getByRole('button', {
-        name: '保育園編集をキャンセル',
-      });
+      const nurseryCancelButton = screen.getAllByText('キャンセル')[0]; // 最初のキャンセルボタン（保育園編集用）
       const questionCancelButton = screen.getByRole('button', {
         name: '質問追加をキャンセル',
       });

--- a/src/pages/NurseryDetailPage.tsx
+++ b/src/pages/NurseryDetailPage.tsx
@@ -239,6 +239,7 @@ export const NurseryDetailPage = () => {
                 onSave={() => void nurseryEdit.handleSaveNursery()}
                 onCancel={nurseryEdit.handleCancelEditNursery}
                 isDisabled={nurseryEdit.isSaveDisabled}
+                cancelContext="保育園編集をキャンセル"
               />
             ) : (
               <Button

--- a/src/pages/NurseryDetailPage.tsx
+++ b/src/pages/NurseryDetailPage.tsx
@@ -280,14 +280,10 @@ export const NurseryDetailPage = () => {
           {/* 質問追加フォーム */}
           <Box mb={2}>
             <QuestionAddForm
-              isAddingQuestion={questionForm.formState.isAdding}
               newQuestionText={questionForm.formState.questionText}
               newAnswerText={questionForm.formState.answerText}
               onNewQuestionTextChange={questionForm.updateQuestionText}
               onNewAnswerTextChange={questionForm.updateAnswerText}
-              onToggleAddForm={(value) =>
-                value ? questionForm.startAdding() : questionForm.cancelAdding()
-              }
               onAddQuestion={() => void handleAddQuestion()}
             />
           </Box>


### PR DESCRIPTION
## Summary
- NurseryCardに右矢印アイコンを追加してクリック可能性を向上
- QuestionAddFormを常に表示する形式に簡略化してUX改善

## 変更内容

### NurseryCard UI改善
- HStackレイアウトで右矢印アイコン（IoChevronForward）を追加
- ユーザーがカードをクリックできることを視覚的に明確化
- カード内のコンテンツ配置をVStackで整理

### QuestionAddForm簡略化
- `isAddingQuestion`状態管理を削除
- `onToggleAddForm`プロパティを削除
- フォーム表示・非表示の切り替えロジックを排除
- 質問追加フローをよりシンプルで直感的に改善
- useQuestionFormからstartAdding/cancelAdding機能を削除

### テスト更新
- QuestionAddForm関連のテストケースを新しい仕様に対応
- NurseryDetailPageテストでUI変更に対応
- 削除ダイアログの複数キャンセルボタン問題を修正

## Test plan
- [x] NurseryCardのクリック機能が正常に動作する
- [x] 右矢印アイコンが適切に表示される
- [x] 質問追加フォームが常に表示される
- [x] 質問追加・編集・削除機能が正常に動作する
- [x] 全てのテストが通過する
- [x] TypeScriptエラーがない

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能/UX
  - 質問追加フォームが常時表示化され、「質問入力」から直接追加・キャンセル（入力クリア）可能に。
  - 保育園カードを横並びにし、右端に進む（chevron）アイコンを追加してクリック性を明確化。

- アクセシビリティ
  - 取消ボタンのaria-labelがコンテキスト付与に対応し、キャンセル操作の文脈が明確に。

- リファクタ
  - 外部による追加モード制御を廃止し、フォーム状態を内部管理に簡素化。

- テスト
  - 多数のテストをUI変更に合わせて更新（セレクタ／ラベル／スコープ調整）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->