### PR TITLE
fix: claude[bot]が作成したPRでもCode Reviewが起動するよう許可

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary
- `claude-code-action` のデフォルト設定が bot 起動を拒否するため、`claude[bot]` が作成した PR で Code Review が `Workflow initiated by non-human actor` エラーで失敗していた
- `.github/workflows/claude-code-review.yml` に `allowed_bots: 'claude[bot]'` を追加してレビューを起動できるようにする

## Test plan
- [ ] このPRがマージされた後、`claude[bot]` が作成した PR でレビューワークフローが正常に走ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)