### PR TITLE
test: テストを Testing Library 推奨クエリに書き換える (testid 削減)

### DIFF
--- a/app/nursery/[id]/edit/memo/page.tsx
+++ b/app/nursery/[id]/edit/memo/page.tsx
@@ -101,17 +101,11 @@ export default function EditMemoPage() {
             size="sm"
             onClick={handleBack}
             className="gap-1 px-2"
-            data-testid="back-button"
           >
             <ChevronLeft className="h-5 w-5" />
             戻る
           </Button>
-          <Button
-            size="sm"
-            onClick={handleSave}
-            disabled={!hasChanges}
-            data-testid="save-button"
-          >
+          <Button size="sm" onClick={handleSave} disabled={!hasChanges}>
             完了
           </Button>
         </div>
@@ -126,7 +120,6 @@ export default function EditMemoPage() {
           placeholder="気づいたことを自由に書けます"
           rows={12}
           className="min-h-[50vh] resize-none"
-          data-testid="edit-memo-textarea"
         />
       </main>
 

--- a/app/nursery/[id]/edit/name/page.tsx
+++ b/app/nursery/[id]/edit/name/page.tsx
@@ -103,7 +103,6 @@ export default function EditNamePage() {
             size="sm"
             onClick={handleBack}
             className="gap-1 px-2"
-            data-testid="back-button"
           >
             <ChevronLeft className="h-5 w-5" />
             戻る
@@ -112,7 +111,6 @@ export default function EditNamePage() {
             size="sm"
             onClick={handleSave}
             disabled={!isValid || !hasChanges}
-            data-testid="save-button"
           >
             完了
           </Button>
@@ -126,10 +124,9 @@ export default function EditNamePage() {
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="園名を入力"
-          data-testid="edit-name-input"
         />
         {!isValid && name.length > 0 && (
-          <p className="mt-2 text-destructive text-sm" data-testid="name-error">
+          <p className="mt-2 text-destructive text-sm">
             園名を入力してください
           </p>
         )}

--- a/app/nursery/[id]/edit/visit-date/page.tsx
+++ b/app/nursery/[id]/edit/visit-date/page.tsx
@@ -82,7 +82,6 @@ export default function EditVisitDatePage() {
             size="sm"
             onClick={() => navigateBack()}
             className="gap-1 px-2"
-            data-testid="back-button"
           >
             <ChevronLeft className="h-5 w-5" />
             戻る

--- a/app/nursery/[id]/page.tsx
+++ b/app/nursery/[id]/page.tsx
@@ -86,7 +86,6 @@ export default function NurseryDetailPage() {
             variant="destructive"
             className="w-full"
             onClick={() => setShowDeleteDialog(true)}
-            data-testid="delete-nursery-button"
           >
             この園を削除する
           </Button>

--- a/components/common/CookieConsent.test.tsx
+++ b/components/common/CookieConsent.test.tsx
@@ -23,7 +23,9 @@ describe("CookieConsent", () => {
 
   it("同意未決定のときバナーが表示される", () => {
     render(<CookieConsent />);
-    expect(screen.getByTestId("cookie-consent-banner")).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: "Cookie使用の同意" }),
+    ).toBeInTheDocument();
     expect(screen.getByText(/Cookieを使用しています/)).toBeInTheDocument();
   });
 
@@ -31,9 +33,9 @@ describe("CookieConsent", () => {
     const user = userEvent.setup();
     render(<CookieConsent />);
 
-    await user.click(screen.getByTestId("cookie-accept-button"));
+    await user.click(screen.getByRole("button", { name: "同意する" }));
     expect(
-      screen.queryByTestId("cookie-consent-banner"),
+      screen.queryByRole("dialog", { name: "Cookie使用の同意" }),
     ).not.toBeInTheDocument();
     expect(localStorage.getItem(STORAGE_KEYS.cookieConsent)).toBe("accepted");
   });
@@ -42,9 +44,9 @@ describe("CookieConsent", () => {
     const user = userEvent.setup();
     render(<CookieConsent />);
 
-    await user.click(screen.getByTestId("cookie-decline-button"));
+    await user.click(screen.getByRole("button", { name: "同意しない" }));
     expect(
-      screen.queryByTestId("cookie-consent-banner"),
+      screen.queryByRole("dialog", { name: "Cookie使用の同意" }),
     ).not.toBeInTheDocument();
     expect(localStorage.getItem(STORAGE_KEYS.cookieConsent)).toBe("declined");
   });
@@ -53,7 +55,7 @@ describe("CookieConsent", () => {
     localStorage.setItem(STORAGE_KEYS.cookieConsent, "accepted");
     render(<CookieConsent />);
     expect(
-      screen.queryByTestId("cookie-consent-banner"),
+      screen.queryByRole("dialog", { name: "Cookie使用の同意" }),
     ).not.toBeInTheDocument();
   });
 });

--- a/components/common/CookieConsent.tsx
+++ b/components/common/CookieConsent.tsx
@@ -27,7 +27,6 @@ export function CookieConsent() {
           role="dialog"
           aria-label="Cookie使用の同意"
           className="fixed inset-x-0 bottom-0 z-50 border-t bg-background p-4 shadow-lg"
-          data-testid="cookie-consent-banner"
         >
           <div className="mx-auto max-w-lg">
             <p className="mb-3 text-sm">
@@ -36,19 +35,10 @@ export function CookieConsent() {
               Clarity）にのみ使用し、入力された園の情報は送信しません。
             </p>
             <div className="flex gap-2">
-              <Button
-                size="sm"
-                onClick={accept}
-                data-testid="cookie-accept-button"
-              >
+              <Button size="sm" onClick={accept}>
                 同意する
               </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={decline}
-                data-testid="cookie-decline-button"
-              >
+              <Button size="sm" variant="outline" onClick={decline}>
                 同意しない
               </Button>
             </div>

--- a/components/layout/EmptyState.tsx
+++ b/components/layout/EmptyState.tsx
@@ -14,10 +14,7 @@ export function EmptyState({
   showAddButton = false,
 }: EmptyStateProps) {
   return (
-    <div
-      className="flex flex-col items-center justify-center py-12 text-center"
-      data-testid="empty-state"
-    >
+    <div className="flex flex-col items-center justify-center py-12 text-center">
       <p className="font-medium text-lg text-muted-foreground">{message}</p>
       {description && (
         <p className="mt-2 text-muted-foreground text-sm">{description}</p>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -17,7 +17,6 @@ export function Header({ onHelpClick }: HeaderProps) {
           size="icon"
           onClick={onHelpClick}
           aria-label="ヘルプ"
-          data-testid="header-help-button"
         >
           <CircleHelp className="h-5 w-5" />
         </Button>

--- a/components/nursery/DeleteNurseryDialog.test.tsx
+++ b/components/nursery/DeleteNurseryDialog.test.tsx
@@ -33,7 +33,7 @@ describe("DeleteNurseryDialog", () => {
       />,
     );
 
-    await user.click(screen.getByTestId("delete-confirm-button"));
+    await user.click(screen.getByRole("button", { name: "削除" }));
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
@@ -49,7 +49,7 @@ describe("DeleteNurseryDialog", () => {
       />,
     );
 
-    await user.click(screen.getByTestId("delete-cancel-button"));
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 

--- a/components/nursery/DeleteNurseryDialog.tsx
+++ b/components/nursery/DeleteNurseryDialog.tsx
@@ -26,7 +26,7 @@ export function DeleteNurseryDialog({
 }: DeleteNurseryDialogProps) {
   return (
     <AlertDialog open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
-      <AlertDialogContent data-testid="delete-nursery-dialog">
+      <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>この園を削除しますか？</AlertDialogTitle>
           <AlertDialogDescription>
@@ -34,14 +34,8 @@ export function DeleteNurseryDialog({
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel data-testid="delete-cancel-button">
-            キャンセル
-          </AlertDialogCancel>
-          <AlertDialogAction
-            onClick={onConfirm}
-            variant="destructive"
-            data-testid="delete-confirm-button"
-          >
+          <AlertDialogCancel>キャンセル</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm} variant="destructive">
             削除
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/components/nursery/DiscardChangesDialog.test.tsx
+++ b/components/nursery/DiscardChangesDialog.test.tsx
@@ -33,7 +33,7 @@ describe("DiscardChangesDialog", () => {
       />,
     );
 
-    await user.click(screen.getByTestId("discard-confirm-button"));
+    await user.click(screen.getByRole("button", { name: "破棄" }));
     expect(onDiscard).toHaveBeenCalledTimes(1);
   });
 
@@ -48,7 +48,7 @@ describe("DiscardChangesDialog", () => {
       />,
     );
 
-    await user.click(screen.getByTestId("discard-cancel-button"));
+    await user.click(screen.getByRole("button", { name: "編集を続ける" }));
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 

--- a/components/nursery/DiscardChangesDialog.tsx
+++ b/components/nursery/DiscardChangesDialog.tsx
@@ -24,7 +24,7 @@ export function DiscardChangesDialog({
 }: DiscardChangesDialogProps) {
   return (
     <AlertDialog open={open}>
-      <AlertDialogContent size="sm" data-testid="discard-changes-dialog">
+      <AlertDialogContent size="sm">
         <AlertDialogHeader>
           <AlertDialogTitle>変更を破棄しますか？</AlertDialogTitle>
           <AlertDialogDescription>
@@ -32,17 +32,8 @@ export function DiscardChangesDialog({
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel
-            onClick={onCancel}
-            data-testid="discard-cancel-button"
-          >
-            編集を続ける
-          </AlertDialogCancel>
-          <AlertDialogAction
-            variant="destructive"
-            onClick={onDiscard}
-            data-testid="discard-confirm-button"
-          >
+          <AlertDialogCancel onClick={onCancel}>編集を続ける</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={onDiscard}>
             破棄
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/components/nursery/NurseryCard.test.tsx
+++ b/components/nursery/NurseryCard.test.tsx
@@ -43,13 +43,13 @@ describe("NurseryCard", () => {
 
   it("メモが空の場合プレビューが表示されない", () => {
     render(<NurseryCard nursery={mockNursery} />);
-    const link = screen.getByRole("link");
+    const link = screen.getByRole("link", { name: "さくら保育園" });
     expect(link.querySelectorAll("p")).toHaveLength(0);
   });
 
   it("園詳細へのリンクが設定されている", () => {
     render(<NurseryCard nursery={mockNursery} />);
-    const link = screen.getByRole("link");
+    const link = screen.getByRole("link", { name: "さくら保育園" });
     expect(link).toHaveAttribute("href", "/nursery/test-1");
   });
 });

--- a/components/nursery/NurseryCard.test.tsx
+++ b/components/nursery/NurseryCard.test.tsx
@@ -43,13 +43,13 @@ describe("NurseryCard", () => {
 
   it("メモが空の場合プレビューが表示されない", () => {
     render(<NurseryCard nursery={mockNursery} />);
-    const card = screen.getByTestId("nursery-card-test-1");
-    expect(card.querySelectorAll("p")).toHaveLength(0);
+    const link = screen.getByRole("link");
+    expect(link.querySelectorAll("p")).toHaveLength(0);
   });
 
   it("園詳細へのリンクが設定されている", () => {
     render(<NurseryCard nursery={mockNursery} />);
-    const link = screen.getByTestId("nursery-card-test-1");
+    const link = screen.getByRole("link");
     expect(link).toHaveAttribute("href", "/nursery/test-1");
   });
 });

--- a/components/nursery/NurseryCard.tsx
+++ b/components/nursery/NurseryCard.tsx
@@ -14,7 +14,6 @@ export function NurseryCard({ nursery }: NurseryCardProps) {
       href={`/nursery/${nursery.id}`}
       direction="forward"
       className="block rounded-lg border bg-card p-4 shadow-sm transition-colors hover:bg-accent/50"
-      data-testid={`nursery-card-${nursery.id}`}
     >
       <div className="flex items-start justify-between gap-2">
         <h2 className="font-medium text-base">{nursery.name}</h2>

--- a/components/nursery/NurseryDetail.test.tsx
+++ b/components/nursery/NurseryDetail.test.tsx
@@ -20,10 +20,8 @@ describe("NurseryDetail", () => {
 
   it("園名・見学日・メモが表示される", () => {
     render(<NurseryDetail nursery={mockNursery} onVisitTipsClick={vi.fn()} />);
-    expect(screen.getByTestId("nursery-name")).toHaveTextContent(
-      "さくら保育園",
-    );
-    expect(screen.getByTestId("visit-date")).toHaveTextContent("2026/4/15");
+    expect(screen.getByText("さくら保育園")).toBeInTheDocument();
+    expect(screen.getByText("2026/4/15")).toBeInTheDocument();
     expect(screen.getByText("園庭が広い")).toBeInTheDocument();
   });
 
@@ -39,21 +37,27 @@ describe("NurseryDetail", () => {
     ).toBeInTheDocument();
   });
 
-  it("園名行にchevronとリンクが表示される", () => {
+  it("園名行のリンクが正しい href を持つ", () => {
     render(<NurseryDetail nursery={mockNursery} onVisitTipsClick={vi.fn()} />);
-    const nameLink = screen.getByTestId("edit-name-link");
+    const nameLink = screen.getByRole("link", {
+      name: "園名を編集: さくら保育園",
+    });
     expect(nameLink).toHaveAttribute("href", "/nursery/test-1/edit/name");
   });
 
-  it("見学日行にchevronとリンクが表示される", () => {
+  it("見学日行のリンクが正しい href を持つ", () => {
     render(<NurseryDetail nursery={mockNursery} onVisitTipsClick={vi.fn()} />);
-    const dateLink = screen.getByTestId("edit-date-link");
+    const dateLink = screen.getByRole("link", {
+      name: "見学日を編集: 2026/4/15",
+    });
     expect(dateLink).toHaveAttribute("href", "/nursery/test-1/edit/visit-date");
   });
 
-  it("メモ行にchevronとリンクが表示される", () => {
+  it("メモ行のリンクが正しい href を持つ", () => {
     render(<NurseryDetail nursery={mockNursery} onVisitTipsClick={vi.fn()} />);
-    const memoLink = screen.getByTestId("edit-memo-link");
+    const memoLink = screen.getByRole("link", {
+      name: "メモを編集: 園庭が広い",
+    });
     expect(memoLink).toHaveAttribute("href", "/nursery/test-1/edit/memo");
   });
 
@@ -67,7 +71,7 @@ describe("NurseryDetail", () => {
       />,
     );
 
-    await user.click(screen.getByTestId("visit-tips-link"));
+    await user.click(screen.getByRole("button", { name: "見学のコツを見る" }));
     expect(onVisitTipsClick).toHaveBeenCalledTimes(1);
   });
 
@@ -78,6 +82,6 @@ describe("NurseryDetail", () => {
         onVisitTipsClick={vi.fn()}
       />,
     );
-    expect(screen.getByTestId("visit-date")).toHaveTextContent("未定");
+    expect(screen.getByText("未定")).toBeInTheDocument();
   });
 });

--- a/components/nursery/NurseryDetail.tsx
+++ b/components/nursery/NurseryDetail.tsx
@@ -18,20 +18,17 @@ export function NurseryDetail({
   const formattedDate = formatVisitDate(nursery.visitDate);
 
   return (
-    <div className="space-y-6" data-testid="nursery-detail">
+    <div className="space-y-6">
       <div className="overflow-hidden rounded-xl border bg-card">
         <SlideLink
           href={`/nursery/${nursery.id}/edit/name`}
           direction="forward"
           className="flex items-center justify-between px-4 py-3 active:bg-accent"
-          data-testid="edit-name-link"
           aria-label={`園名を編集: ${nursery.name}`}
         >
           <div className="min-w-0 flex-1">
             <p className="text-xs text-muted-foreground">園名</p>
-            <p className="truncate font-medium" data-testid="nursery-name">
-              {nursery.name}
-            </p>
+            <p className="truncate font-medium">{nursery.name}</p>
           </div>
           <ChevronRight
             className="ml-2 h-5 w-5 shrink-0 text-muted-foreground"
@@ -45,14 +42,11 @@ export function NurseryDetail({
           href={`/nursery/${nursery.id}/edit/visit-date`}
           direction="forward"
           className="flex items-center justify-between px-4 py-3 active:bg-accent"
-          data-testid="edit-date-link"
           aria-label={`見学日を編集: ${formattedDate}`}
         >
           <div className="min-w-0 flex-1">
             <p className="text-xs text-muted-foreground">見学日</p>
-            <p className="truncate" data-testid="visit-date">
-              {formattedDate}
-            </p>
+            <p className="truncate">{formattedDate}</p>
           </div>
           <ChevronRight
             className="ml-2 h-5 w-5 shrink-0 text-muted-foreground"
@@ -66,7 +60,6 @@ export function NurseryDetail({
           href={`/nursery/${nursery.id}/edit/memo`}
           direction="forward"
           className="flex items-center justify-between px-4 py-3 active:bg-accent"
-          data-testid="edit-memo-link"
           aria-label={
             nursery.memo ? `メモを編集: ${nursery.memo}` : "メモを追加"
           }
@@ -74,17 +67,11 @@ export function NurseryDetail({
           <div className="min-w-0 flex-1">
             <p className="text-xs text-muted-foreground">メモ</p>
             {nursery.memo ? (
-              <p
-                className="whitespace-pre-wrap break-words text-sm"
-                data-testid="memo-display"
-              >
+              <p className="whitespace-pre-wrap break-words text-sm">
                 {nursery.memo}
               </p>
             ) : (
-              <p
-                className="text-sm text-muted-foreground"
-                data-testid="memo-display"
-              >
+              <p className="text-sm text-muted-foreground">
                 気づいたことを自由に書けます
               </p>
             )}
@@ -97,12 +84,7 @@ export function NurseryDetail({
       </div>
 
       <div>
-        <Button
-          variant="link"
-          onClick={onVisitTipsClick}
-          className="px-0"
-          data-testid="visit-tips-link"
-        >
+        <Button variant="link" onClick={onVisitTipsClick} className="px-0">
           見学のコツを見る
         </Button>
       </div>

--- a/components/nursery/NurseryForm.test.tsx
+++ b/components/nursery/NurseryForm.test.tsx
@@ -13,27 +13,30 @@ describe("NurseryForm", () => {
     render(<NurseryForm onAdd={vi.fn()} />);
     expect(screen.getByLabelText("園名")).toBeInTheDocument();
     expect(screen.getByText("見学日")).toBeInTheDocument();
-    expect(screen.getByTestId("add-nursery-button")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "追加する" }),
+    ).toBeInTheDocument();
   });
 
   it("園名が空の場合、追加ボタンが非活性", () => {
     render(<NurseryForm onAdd={vi.fn()} />);
-    expect(screen.getByTestId("add-nursery-button")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "追加する" })).toBeDisabled();
   });
 
   it("「今日」と「あとで設定する」の選択肢がある", () => {
     render(<NurseryForm onAdd={vi.fn()} />);
-    expect(screen.getByTestId("visit-date-today")).toBeInTheDocument();
-    expect(screen.getByTestId("visit-date-later")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "今日" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "あとで設定する" }),
+    ).toBeInTheDocument();
   });
 
   it("デフォルトは「あとで設定する」が選択されている", () => {
     render(<NurseryForm onAdd={vi.fn()} />);
-    expect(screen.getByTestId("visit-date-later")).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-    expect(screen.getByTestId("visit-date-today")).toHaveAttribute(
+    expect(
+      screen.getByRole("button", { name: "あとで設定する" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "今日" })).toHaveAttribute(
       "aria-pressed",
       "false",
     );
@@ -44,8 +47,8 @@ describe("NurseryForm", () => {
     const onAdd = vi.fn();
     render(<NurseryForm onAdd={onAdd} />);
 
-    await user.type(screen.getByTestId("nursery-name-input"), "さくら保育園");
-    await user.click(screen.getByTestId("add-nursery-button"));
+    await user.type(screen.getByLabelText("園名"), "さくら保育園");
+    await user.click(screen.getByRole("button", { name: "追加する" }));
 
     expect(onAdd).toHaveBeenCalledWith("さくら保育園", null);
   });
@@ -55,14 +58,13 @@ describe("NurseryForm", () => {
     const onAdd = vi.fn();
     render(<NurseryForm onAdd={onAdd} />);
 
-    await user.type(screen.getByTestId("nursery-name-input"), "ひまわり保育園");
-    await user.click(screen.getByTestId("visit-date-today"));
-    await user.click(screen.getByTestId("add-nursery-button"));
+    await user.type(screen.getByLabelText("園名"), "ひまわり保育園");
+    await user.click(screen.getByRole("button", { name: "今日" }));
+    await user.click(screen.getByRole("button", { name: "追加する" }));
 
     expect(onAdd).toHaveBeenCalledTimes(1);
     const [calledName, calledDate] = onAdd.mock.calls[0];
     expect(calledName).toBe("ひまわり保育園");
-    // ISO date format check (YYYY-MM-DD)
     expect(calledDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 });

--- a/components/nursery/NurseryForm.tsx
+++ b/components/nursery/NurseryForm.tsx
@@ -29,11 +29,7 @@ export function NurseryForm({ onAdd }: NurseryFormProps) {
   };
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="space-y-6"
-      data-testid="nursery-form"
-    >
+    <form onSubmit={handleSubmit} className="space-y-6">
       <div className="space-y-2">
         <Label htmlFor="nursery-name">園名</Label>
         <Input
@@ -42,7 +38,6 @@ export function NurseryForm({ onAdd }: NurseryFormProps) {
           placeholder="例：さくら保育園"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          data-testid="nursery-name-input"
         />
       </div>
 
@@ -59,7 +54,6 @@ export function NurseryForm({ onAdd }: NurseryFormProps) {
                 ? "border-primary bg-primary/5 text-primary"
                 : "border-border text-muted-foreground hover:border-primary/50",
             )}
-            data-testid="visit-date-today"
           >
             今日
           </button>
@@ -73,19 +67,13 @@ export function NurseryForm({ onAdd }: NurseryFormProps) {
                 ? "border-primary bg-primary/5 text-primary"
                 : "border-border text-muted-foreground hover:border-primary/50",
             )}
-            data-testid="visit-date-later"
           >
             あとで設定する
           </button>
         </div>
       </div>
 
-      <Button
-        type="submit"
-        className="w-full"
-        disabled={!isValid}
-        data-testid="add-nursery-button"
-      >
+      <Button type="submit" className="w-full" disabled={!isValid}>
         追加する
       </Button>
     </form>

--- a/components/nursery/NurseryList.test.tsx
+++ b/components/nursery/NurseryList.test.tsx
@@ -32,6 +32,8 @@ describe("NurseryList", () => {
   it("園が0件の場合、空状態メッセージが表示される", () => {
     render(<NurseryList nurseries={[]} />);
     expect(screen.getByText("まだ園が登録されていません")).toBeInTheDocument();
-    expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+    expect(
+      screen.getByText("見学候補の園を追加しましょう"),
+    ).toBeInTheDocument();
   });
 });

--- a/components/nursery/NurseryList.tsx
+++ b/components/nursery/NurseryList.tsx
@@ -18,7 +18,7 @@ export function NurseryList({ nurseries }: NurseryListProps) {
   }
 
   return (
-    <ul className="space-y-3" data-testid="nursery-list">
+    <ul className="space-y-3">
       {nurseries.map((nursery) => (
         <li key={nursery.id}>
           <NurseryCard nursery={nursery} />

--- a/components/nursery/VisitTipsDialog.test.tsx
+++ b/components/nursery/VisitTipsDialog.test.tsx
@@ -21,7 +21,8 @@ describe("VisitTipsDialog", () => {
     const onClose = vi.fn();
     render(<VisitTipsDialog open={true} onClose={onClose} />);
 
-    await user.click(screen.getByTestId("visit-tips-close-button"));
+    const closeButtons = screen.getAllByRole("button", { name: "閉じる" });
+    await user.click(closeButtons[closeButtons.length - 1]);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/components/nursery/VisitTipsDialog.test.tsx
+++ b/components/nursery/VisitTipsDialog.test.tsx
@@ -21,8 +21,9 @@ describe("VisitTipsDialog", () => {
     const onClose = vi.fn();
     render(<VisitTipsDialog open={true} onClose={onClose} />);
 
-    const closeButtons = screen.getAllByRole("button", { name: "閉じる" });
-    await user.click(closeButtons[closeButtons.length - 1]);
+    await user.click(
+      screen.getByRole("button", { name: "見学のコツを閉じる" }),
+    );
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/components/nursery/VisitTipsDialog.tsx
+++ b/components/nursery/VisitTipsDialog.tsx
@@ -36,7 +36,7 @@ const VISIT_TIPS = [
 export function VisitTipsDialog({ open, onClose }: VisitTipsDialogProps) {
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent data-testid="visit-tips-dialog">
+      <DialogContent>
         <DialogHeader>
           <DialogTitle>見学のコツ</DialogTitle>
           <DialogDescription>
@@ -56,11 +56,7 @@ export function VisitTipsDialog({ open, onClose }: VisitTipsDialogProps) {
         </div>
 
         <DialogFooter>
-          <Button
-            onClick={onClose}
-            className="w-full"
-            data-testid="visit-tips-close-button"
-          >
+          <Button onClick={onClose} className="w-full">
             閉じる
           </Button>
         </DialogFooter>

--- a/components/nursery/VisitTipsDialog.tsx
+++ b/components/nursery/VisitTipsDialog.tsx
@@ -56,7 +56,11 @@ export function VisitTipsDialog({ open, onClose }: VisitTipsDialogProps) {
         </div>
 
         <DialogFooter>
-          <Button onClick={onClose} className="w-full">
+          <Button
+            onClick={onClose}
+            className="w-full"
+            aria-label="見学のコツを閉じる"
+          >
             閉じる
           </Button>
         </DialogFooter>

--- a/components/onboarding/OnboardingDialog.test.tsx
+++ b/components/onboarding/OnboardingDialog.test.tsx
@@ -40,7 +40,7 @@ describe("OnboardingDialog", () => {
     const onClose = vi.fn();
     render(<OnboardingDialog open={true} onClose={onClose} />);
 
-    await user.click(screen.getByTestId("onboarding-start-button"));
+    await user.click(screen.getByRole("button", { name: "はじめる" }));
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/components/onboarding/OnboardingDialog.tsx
+++ b/components/onboarding/OnboardingDialog.tsx
@@ -18,7 +18,7 @@ interface OnboardingDialogProps {
 export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent showCloseButton={false} data-testid="onboarding-dialog">
+      <DialogContent showCloseButton={false}>
         <DialogHeader>
           <DialogTitle>保活手帳へようこそ</DialogTitle>
           <DialogDescription>
@@ -46,11 +46,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
         </div>
 
         <DialogFooter>
-          <Button
-            onClick={onClose}
-            className="w-full"
-            data-testid="onboarding-start-button"
-          >
+          <Button onClick={onClose} className="w-full">
             はじめる
           </Button>
         </DialogFooter>

--- a/components/ui/calendar-picker.test.tsx
+++ b/components/ui/calendar-picker.test.tsx
@@ -13,22 +13,17 @@ describe("CalendarPicker", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-02"));
     render(<CalendarPicker selectedDate="2026-04-15" onSelect={vi.fn()} />);
-    expect(screen.getByTestId("calendar-picker")).toBeInTheDocument();
-    expect(screen.getByTestId("month-label")).toHaveTextContent("2026年4月");
+    expect(screen.getByRole("grid", { name: "2026年4月" })).toBeInTheDocument();
   });
 
   it("選択中の日付が日本語形式で表示される", () => {
     render(<CalendarPicker selectedDate="2026-04-15" onSelect={vi.fn()} />);
-    expect(screen.getByTestId("selected-date-display")).toHaveTextContent(
-      "2026年4月15日（水）",
-    );
+    expect(screen.getByText("2026年4月15日（水）")).toBeInTheDocument();
   });
 
   it("未定の場合「未定」と表示される", () => {
     render(<CalendarPicker selectedDate={null} onSelect={vi.fn()} />);
-    expect(screen.getByTestId("selected-date-display")).toHaveTextContent(
-      "未定",
-    );
+    expect(screen.getByText("未定")).toBeInTheDocument();
   });
 
   it("日付をクリックするとonSelectが呼ばれる", async () => {
@@ -36,7 +31,7 @@ describe("CalendarPicker", () => {
     const onSelect = vi.fn();
     render(<CalendarPicker selectedDate="2026-04-15" onSelect={onSelect} />);
 
-    await user.click(screen.getByTestId("day-10"));
+    await user.click(screen.getByRole("button", { name: "2026年4月10日" }));
     expect(onSelect).toHaveBeenCalledWith("2026-04-10");
   });
 
@@ -44,16 +39,16 @@ describe("CalendarPicker", () => {
     const user = userEvent.setup();
     render(<CalendarPicker selectedDate="2026-04-15" onSelect={vi.fn()} />);
 
-    await user.click(screen.getByTestId("prev-month-button"));
-    expect(screen.getByTestId("month-label")).toHaveTextContent("2026年3月");
+    await user.click(screen.getByRole("button", { name: "前の月" }));
+    expect(screen.getByRole("grid", { name: "2026年3月" })).toBeInTheDocument();
   });
 
   it("次月ボタンで月が切り替わる", async () => {
     const user = userEvent.setup();
     render(<CalendarPicker selectedDate="2026-04-15" onSelect={vi.fn()} />);
 
-    await user.click(screen.getByTestId("next-month-button"));
-    expect(screen.getByTestId("month-label")).toHaveTextContent("2026年5月");
+    await user.click(screen.getByRole("button", { name: "次の月" }));
+    expect(screen.getByRole("grid", { name: "2026年5月" })).toBeInTheDocument();
   });
 
   it("未定にするボタンでnullが返される", async () => {
@@ -61,7 +56,7 @@ describe("CalendarPicker", () => {
     const onSelect = vi.fn();
     render(<CalendarPicker selectedDate="2026-04-15" onSelect={onSelect} />);
 
-    await user.click(screen.getByTestId("set-undecided-button"));
+    await user.click(screen.getByRole("button", { name: "未定にする" }));
     expect(onSelect).toHaveBeenCalledWith(null);
   });
 
@@ -69,12 +64,12 @@ describe("CalendarPicker", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-02"));
     render(<CalendarPicker selectedDate={null} onSelect={vi.fn()} />);
-    expect(screen.getByTestId("month-label")).toHaveTextContent("2026年4月");
+    expect(screen.getByRole("grid", { name: "2026年4月" })).toBeInTheDocument();
   });
 
   it("選択中の日付がハイライトされる", () => {
     render(<CalendarPicker selectedDate="2026-04-15" onSelect={vi.fn()} />);
-    const day15 = screen.getByTestId("day-15");
+    const day15 = screen.getByRole("button", { name: "2026年4月15日" });
     expect(day15).toHaveAttribute("aria-pressed", "true");
   });
 });

--- a/components/ui/calendar-picker.tsx
+++ b/components/ui/calendar-picker.tsx
@@ -68,8 +68,8 @@ export function CalendarPicker({
   const monthLabel = `${viewYear}年${viewMonth + 1}月`;
 
   return (
-    <div data-testid="calendar-picker">
-      <div className="mb-4 text-center" data-testid="selected-date-display">
+    <div>
+      <div className="mb-4 text-center">
         {selectedDate ? (
           <p className="font-medium text-lg">{formatDateJP(selectedDate)}</p>
         ) : (
@@ -83,19 +83,15 @@ export function CalendarPicker({
           size="icon"
           onClick={prevMonth}
           aria-label="前の月"
-          data-testid="prev-month-button"
         >
           <ChevronLeft className="h-5 w-5" />
         </Button>
-        <span className="font-medium" data-testid="month-label">
-          {monthLabel}
-        </span>
+        <span className="font-medium">{monthLabel}</span>
         <Button
           variant="ghost"
           size="icon"
           onClick={nextMonth}
           aria-label="次の月"
-          data-testid="next-month-button"
         >
           <ChevronRight className="h-5 w-5" />
         </Button>
@@ -139,7 +135,6 @@ export function CalendarPicker({
               )}
               aria-label={`${viewYear}年${viewMonth + 1}月${day}日`}
               aria-pressed={isSelected}
-              data-testid={`day-${day}`}
             >
               {day}
             </button>
@@ -152,7 +147,6 @@ export function CalendarPicker({
           variant="outline"
           className="w-full"
           onClick={() => onSelect(null)}
-          data-testid="set-undecided-button"
         >
           未定にする
         </Button>

--- a/components/ui/calendar-picker.tsx
+++ b/components/ui/calendar-picker.tsx
@@ -133,7 +133,7 @@ export function CalendarPicker({
                 !isSelected && isToday && "border border-primary text-primary",
                 !isSelected && !isToday && "hover:bg-accent active:bg-accent",
               )}
-              aria-label={`${viewYear}年${viewMonth + 1}月${day}日`}
+              aria-label={`${monthLabel}${day}日`}
               aria-pressed={isSelected}
             >
               {day}

--- a/components/ui/toast.test.tsx
+++ b/components/ui/toast.test.tsx
@@ -20,7 +20,7 @@ describe("ToastContainer", () => {
     render(<ToastContainer toasts={toasts} onRemove={vi.fn()} />);
 
     expect(screen.getByText("保存しました")).toBeInTheDocument();
-    expect(screen.getByTestId("toast-container")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toBeInTheDocument();
   });
 
   it("エラートーストが表示される", () => {
@@ -35,8 +35,7 @@ describe("ToastContainer", () => {
   it("トーストが空の場合はコンテナは存在するがトーストは表示されない", () => {
     render(<ToastContainer toasts={[]} onRemove={vi.fn()} />);
 
-    expect(screen.getByTestId("toast-container")).toBeInTheDocument();
-    expect(screen.queryByTestId("toast-message")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toBeEmptyDOMElement();
   });
 
   it("一定時間後にonRemoveが呼ばれる", () => {
@@ -67,8 +66,7 @@ describe("ToastContainer", () => {
   it("role=statusとaria-live=politeが常に設定されている", () => {
     render(<ToastContainer toasts={[]} onRemove={vi.fn()} />);
 
-    const container = screen.getByTestId("toast-container");
-    expect(container).toHaveAttribute("role", "status");
+    const container = screen.getByRole("status");
     expect(container).toHaveAttribute("aria-live", "polite");
   });
 });

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -30,7 +30,6 @@ function ToastItem({ toast, onRemove }: ToastProps) {
           ? "bg-foreground/90 text-background"
           : "bg-destructive text-white",
       )}
-      data-testid="toast-message"
     >
       {toast.type === "success" ? (
         <Check className="h-4 w-4" aria-hidden="true" />
@@ -53,7 +52,6 @@ export function ToastContainer({ toasts, onRemove }: ToastContainerProps) {
       className="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 flex-col items-center gap-2"
       role="status"
       aria-live="polite"
-      data-testid="toast-container"
     >
       {toasts.map((toast) => (
         <ToastItem key={toast.id} toast={toast} onRemove={onRemove} />


### PR DESCRIPTION
## Summary

- 11 テストファイルから `getByTestId` 参照を 49 → 0 件に削減し、`getByRole` / `getByLabelText` / `getByText` で書き換え
- 実装側の `data-testid` 属性を計 24 個削除（テスト未参照のものも含む）
- `VisitTipsDialog` の Footer 閉じるボタンに固有 `aria-label`「見学のコツを閉じる」を付与し、Radix Dialog の sr-only Close との accessible name 衝突を解消
- `CalendarPicker` の日付 `aria-label` 生成で既存 `monthLabel` を再利用し、ループ内文字列補間の重複を排除

Closes #145

## Test plan

- [x] `npm test` 全 80 件緑
- [x] `npm run check`（Biome）通過
- [x] `grep -rn "data-testid" components app` の残存ゼロ件
- [x] `grep -rn "getByTestId" components app` の残存ゼロ件

## 関連 / 別 Issue

書き換え過程で発見した編集ページ (`app/nursery/[id]/edit/{name,memo}`) の `<input>` / `<textarea>` に `<Label>` が紐付いていない件は **#149** に切り出し済み。本 PR ではノータッチ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクタリング**
  * テスト用の属性（data-testid）を多数削除し、アクセシビリティ（role/label/visible text）に基づくテストクエリへ移行しました。UIや動作に対するユーザー向けの変更はありません。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chiilog/hokatsu-techo.com/pull/150)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->