### PR TITLE
feat(a11y): 編集ページの input/textarea に label を関連付ける

### DIFF
--- a/app/nursery/[id]/edit/memo/page.test.tsx
+++ b/app/nursery/[id]/edit/memo/page.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useNurseryStore } from "@/stores/nurseryStore";
+import EditMemoPage from "./page";
+
+vi.mock("next/navigation", async () => {
+  const actual =
+    await vi.importActual<typeof import("next/navigation")>("next/navigation");
+  return {
+    ...actual,
+    useParams: () => ({ id: "test-1" }),
+    useRouter: () => ({
+      push: vi.fn(),
+      replace: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      prefetch: vi.fn(),
+    }),
+  };
+});
+
+describe("EditMemoPage", () => {
+  beforeEach(() => {
+    useNurseryStore.setState({
+      nurseries: [
+        {
+          id: "test-1",
+          name: "さくら保育園",
+          visitDate: null,
+          memo: "園庭が広い",
+          createdAt: "2026-03-01T00:00:00.000Z",
+          updatedAt: "2026-03-01T00:00:00.000Z",
+        },
+      ],
+      hasSeenOnboarding: true,
+      hasSeenVisitTips: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("メモラベルで入力欄を取得できる", async () => {
+    render(<EditMemoPage />);
+    expect(await screen.findByLabelText("メモ")).toBeInTheDocument();
+  });
+
+  it("既存のメモが初期値として表示される", async () => {
+    render(<EditMemoPage />);
+    expect(await screen.findByLabelText("メモ")).toHaveValue("園庭が広い");
+  });
+});

--- a/app/nursery/[id]/edit/memo/page.tsx
+++ b/app/nursery/[id]/edit/memo/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { DiscardChangesDialog } from "@/components/nursery/DiscardChangesDialog";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { ToastContainer } from "@/components/ui/toast";
 import { useHydrated } from "@/hooks/useHydrated";
@@ -113,8 +114,12 @@ export default function EditMemoPage() {
 
       <main className="mx-auto max-w-lg px-4 py-6">
         <h1 className="mb-6 font-bold text-lg">メモを編集</h1>
+        <Label htmlFor="nursery-memo" className="sr-only">
+          メモ
+        </Label>
         <Textarea
           ref={textareaRef}
+          id="nursery-memo"
           value={memo}
           onChange={(e) => setMemo(e.target.value)}
           placeholder="気づいたことを自由に書けます"

--- a/app/nursery/[id]/edit/name/page.test.tsx
+++ b/app/nursery/[id]/edit/name/page.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useNurseryStore } from "@/stores/nurseryStore";
+import EditNamePage from "./page";
+
+vi.mock("next/navigation", async () => {
+  const actual =
+    await vi.importActual<typeof import("next/navigation")>("next/navigation");
+  return {
+    ...actual,
+    useParams: () => ({ id: "test-1" }),
+    useRouter: () => ({
+      push: vi.fn(),
+      replace: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      prefetch: vi.fn(),
+    }),
+  };
+});
+
+describe("EditNamePage", () => {
+  beforeEach(() => {
+    useNurseryStore.setState({
+      nurseries: [
+        {
+          id: "test-1",
+          name: "さくら保育園",
+          visitDate: null,
+          memo: "",
+          createdAt: "2026-03-01T00:00:00.000Z",
+          updatedAt: "2026-03-01T00:00:00.000Z",
+        },
+      ],
+      hasSeenOnboarding: true,
+      hasSeenVisitTips: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("園名ラベルで入力欄を取得できる", async () => {
+    render(<EditNamePage />);
+    expect(await screen.findByLabelText("園名")).toBeInTheDocument();
+  });
+
+  it("既存の園名が初期値として表示される", async () => {
+    render(<EditNamePage />);
+    expect(await screen.findByLabelText("園名")).toHaveValue("さくら保育園");
+  });
+});

--- a/app/nursery/[id]/edit/name/page.tsx
+++ b/app/nursery/[id]/edit/name/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import { DiscardChangesDialog } from "@/components/nursery/DiscardChangesDialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { ToastContainer } from "@/components/ui/toast";
 import { useHydrated } from "@/hooks/useHydrated";
 import { useToast } from "@/hooks/useToast";
@@ -119,8 +120,12 @@ export default function EditNamePage() {
 
       <main className="mx-auto max-w-lg px-4 py-6">
         <h1 className="mb-6 font-bold text-lg">園名を編集</h1>
+        <Label htmlFor="nursery-name" className="sr-only">
+          園名
+        </Label>
         <Input
           ref={inputRef}
+          id="nursery-name"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="園名を入力"


### PR DESCRIPTION
## Summary

- 園名・メモ編集ページの入力欄に `<Label htmlFor>` + `id` を追加し、accessible name を付与
- Label は `sr-only` で視覚的には非表示（h1 が視覚タイトルを担うため）
- 両ページに対してユニットテストを新規追加（`getByLabelText` でアクセス可能なことを検証）

Refs #149

## Test plan

- [x] `npx vitest run --project unit "app/nursery/[id]/edit/name/page.test.tsx" "app/nursery/[id]/edit/memo/page.test.tsx"` がパス（4/4）
- [x] `npm run check`（Biome）がパス
- [ ] `npm run dev` で `/nursery/<id>/edit/name` と `/nursery/<id>/edit/memo` を開き、DevTools Accessibility ペインで accessible name が「園名」「メモ」になっていることを確認
- [ ] 視覚的な見た目に変化がないこと（sr-only で非表示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * メモ編集ページと保育園名編集ページのフォームアクセシビリティを向上させました。スクリーンリーダー対応のラベルを追加し、より使いやすくしています。

* **テスト**
  * メモ編集ページと保育園名編集ページの新しいテストスイートを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chiilog/hokatsu-techo.com/pull/151)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->