### PR TITLE
test(formatDate): formatVisitDate のユニットテストを追加

### DIFF
--- a/lib/formatDate.test.ts
+++ b/lib/formatDate.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { formatVisitDate } from "@/lib/formatDate";
+
+describe("formatVisitDate", () => {
+  it("正常な日付文字列はja-JPロケールで整形した文字列を返す", () => {
+    expect(formatVisitDate("2026-03-15")).toBe("2026/3/15");
+  });
+
+  it("nullは未定を返す", () => {
+    expect(formatVisitDate(null)).toBe("未定");
+  });
+
+  it("空文字列は未定を返す", () => {
+    expect(formatVisitDate("")).toBe("未定");
+  });
+
+  it("不正な日付文字列は未定を返す", () => {
+    expect(formatVisitDate("invalid-date")).toBe("未定");
+  });
+
+  it("数値化できないトークンを含む文字列は未定を返す", () => {
+    expect(formatVisitDate("2026-03-XX")).toBe("未定");
+  });
+});


### PR DESCRIPTION
## Summary

- `lib/formatDate.ts` の `formatVisitDate` 関数にユニットテストを追加
- 正常系 (`ja-JP` ロケールでの整形)、`null` / 空文字 / 不正な日付文字列のフォールバック (`"未定"`) を網羅
- 純粋関数のため `// @vitest-environment node` で jsdom 起動オーバーヘッドを回避

## Test plan

- [x] `npx vitest run --project unit lib/formatDate.test.ts` で 5 ケースすべて pass
- [x] pre-commit (biome-check) pass

Refs: #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 日付フォーマット機能の包括的なテストスイートを追加しました。正常な日付入力、無効な入力、およびエッジケースのカバレッジを含み、アプリケーションの信頼性が向上しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chiilog/hokatsu-techo.com/pull/152)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->