### PR TITLE
feat: 案B「あたたかい」テーマとダークモードを適用

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,7 +1,19 @@
 import type { Preview } from "@storybook/nextjs-vite";
+import { createElement } from "react";
+import { ThemeProvider } from "../components/common/ThemeProvider";
 import "../app/globals.css";
 
 const preview: Preview = {
+  // 本番と同じく next-themes の ThemeProvider で包む。
+  // これがないと ThemeToggle 等の useTheme() が provider 外になり無効化される。
+  decorators: [
+    (Story) =>
+      createElement(
+        ThemeProvider,
+        { attribute: "class", defaultTheme: "light", enableSystem: true },
+        createElement(Story),
+      ),
+  ],
   parameters: {
     controls: {
       matchers: {

--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -4,7 +4,7 @@
 - **Project Name**: hokatsu-techo (保活手帳)
 - **Project Type**: Greenfield (プロトタイプからのリプレイス)
 - **Start Date**: 2026-03-05T00:00:00Z
-- **Current Stage**: CONSTRUCTION - Build and Test (COMPLETE)
+- **Current Stage**: 案B「あたたかい」テーマ適用 ＋ ダークモード実装 (COMPLETE)
 
 ## Workspace State
 - **Existing Code**: No (ワークスペースルートにソースコードなし)
@@ -41,6 +41,45 @@
 - [ ] Infrastructure Design (SKIP)
 - [x] Code Generation (COMPLETE)
 - [x] Build and Test (COMPLETE)
+
+### 追加要求: 案B「あたたかい」テーマ適用 ＋ ダークモード実装 (2026-06-24)
+- [x] Workspace Detection (resume / brownfield)
+- [x] Requirements Analysis (minimal depth)
+- [ ] User Stories (SKIP - ビジュアル＋トグルのみ、新規ユーザーフローなし)
+- [ ] Application Design (SKIP - 新規コンポーネントは ThemeProvider/ThemeToggle の小規模追加のみ)
+- [x] Code Generation (COMPLETE)
+  - app/globals.css: 案Bカラートークン・角丸(0.875rem)・--font-sans(丸ゴシック)
+  - app/layout.tsx: M_PLUS_Rounded_1c 読込・suppressHydrationWarning・ThemeProvider ラップ
+  - app/manifest.ts: PWA テーマ色を案Bに更新
+  - components/common/ThemeProvider.tsx (新規): next-themes ラッパー
+  - components/layout/ThemeToggle.tsx (新規): ライト⇄ダーク手動トグル(OS追従)
+  - components/layout/Header.tsx: ThemeToggle 組み込み
+  - dependency: next-themes@0.4.6 追加
+- [x] Build and Test (COMPLETE): lint パス / test 106 件パス / build 成功(8ルート)
+
+### 追加要求: デザイン忠実再現（design-system.dc.html 合わせ込み）(2026-06-24)
+- [x] デザイン仕様の精読・差分照合（最大ギャップ＝暖色シャドウの全欠落）
+- [x] Code Generation (COMPLETE)
+  - app/globals.css: 暖色シャドウトークン(card/button/destructive/floating, light/dark)を定義し Tailwind shadow スケールへマップ
+  - components/ui/button.tsx: 700・角丸14px・default/destructive に暖色シャドウ
+  - components/ui/{card,dialog,alert-dialog}.tsx: タイトル font-bold(700)、Dialog/AlertDialog 角丸22px・bg-card
+  - components/ui/input.tsx: 角丸16px・bg-card・focus ボーダー2px
+  - components/nursery/NurseryCard.tsx: 角丸18px・タイトル700・見学日をピーチ pill チップ化
+  - components/nursery/NurseryForm.tsx: セグメント角丸16px・選択時ピーチ塗り+700
+  - components/layout/Header.tsx: 背景 secondary（ピーチ面）
+  - components/layout/EmptyState.tsx: ハートアイコン＋ピーチ円
+- [x] Build and Test (COMPLETE): lint パス / test 106 件パス / build 成功(8ルート)
+
+### 追加要求: 完成版B 取り込み・実装（claude_design MCP / DesignSync）(2026-06-24)
+- [x] claude_design MCP 接続（design 権限付与）・プロジェクト f1a5efc7-... 読み取り
+- [x] 「保活手帳 完成版B.dc.html」(65367字) を取得し design_handoff_warm_theme/ に保存（import）
+- [x] Code Generation (COMPLETE) — 完成版B の未反映「アイコン等」を実装
+  - components/layout/AppLogo.tsx (新規): ブランドハートロゴ(2色塗り・ダーク対応)
+  - components/layout/Header.tsx: ロゴを組み込み
+  - components/onboarding/OnboardingDialog.tsx: ピーチ円+チェックのリスト+プライバシー注記ボックス
+  - components/nursery/VisitTipsDialog.tsx: ピーチ円の番号バッジ
+  - components/nursery/NurseryDetail.tsx: 「見学のコツを見る」にノートアイコン
+- [x] Build and Test (COMPLETE): lint パス(83) / test 106件パス / build 成功(8ルート)
 
 ### OPERATIONS PHASE
 - [ ] Operations (PLACEHOLDER)

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -371,3 +371,67 @@
 **Context**: CONSTRUCTION - Code Generation (Part 2: Generation)
 
 ---
+
+## 新規要求 - 案B「あたたかい」テーマ適用
+**Timestamp**: 2026-06-24T00:00:00Z
+**User Input**: "AI-DLCを使用して、design_handoff_warm_theme/README.md を読んで案Bテーマを適用したい"
+**AI Response**: 既存 AI-DLC プロジェクト（Build and Test 完了済み）への新規要求として受領。design_handoff_warm_theme/README.md および implementation/（globals.css, layout.tsx）を読み込み、現行 app/globals.css・app/layout.tsx との差分を分析。テーマ差し替え（カラートークン・フォント・角丸のみ）のためビジュアル変更に限定、機能・画面構成は不変。ハードコード色は app/manifest.ts の theme_color/background_color のみ確認。低複雑度の brownfield 変更と判定。Workspace Detection（resume found）を完了し、Requirements Analysis（minimal depth）へ進む。
+**Context**: New Request - Workspace Detection (resume) → Requirements Analysis
+
+---
+
+## 案B テーマ適用 - プランニング ＆ スコープ確定
+**Timestamp**: 2026-06-24T00:05:00Z
+**User Input**: "Q1:A, Q2:Next.jsのダークモード実装（next-themes）は必要？" / "B" / "A"
+**AI Response**: Q1=A（manifest 色更新）を承認。ダークモード確認に対し、現行アプリは next-themes/ThemeProvider 不在で .dark トークンが休眠状態である事実を報告。ユーザーは案B（テーマ差し替え＋next-themes 導入）を選択、さらにトグルUIは案A（Header にテーマトグル追加）を選択。スコープを「テーマ差し替え＋ next-themes によるダークモード実機能化＋Headerトグル」に確定。User Stories/Application Design は小規模のため SKIP と判定し、Code Generation を承認のうえ実行。
+**Context**: Requirements Analysis → Workflow Planning → Code Generation (approved)
+
+---
+
+## 案B テーマ適用 - Code Generation 完了
+**Timestamp**: 2026-06-24T00:10:00Z
+**User Input**: N/A（承認済みプランの自動実行）
+**AI Response**: next-themes@0.4.6 追加。新規2ファイル（ThemeProvider.tsx, ThemeToggle.tsx）作成、既存4ファイル（globals.css, layout.tsx, manifest.ts, Header.tsx）更新。検証: `pnpm lint` パス（82ファイル）、`pnpm test` 106件全パス、`pnpm build` 成功（8ルート, TypeScript クリーン）。機能・画面構成は不変、ビジュアル＋ダークモード切替を追加。
+**Context**: Code Generation (Part 2) + Build and Test (COMPLETE)
+
+---
+
+## 案B 忠実再現 - デザインシステム合わせ込み
+**Timestamp**: 2026-06-24T00:30:00Z
+**User Input**: "Claude Designで作成したデザインがあたっていない。どうやって連携したらいい？" / "どれが忠実に再現できそう？" / "A"（実装を design-system.dc.html に合わせ込む）
+**AI Response**: DesignSync はアプリへの自動適用ではなく claude.ai/design ↔ コンポーネントライブラリ同期である旨を説明。忠実再現には design-system.dc.html を正として実装を合わせる選択肢1が最適と助言し承認。design-system.dc.html（03 角丸/余白/影・04 コンポーネント）を精読し、暖色シャドウの全欠落を最大ギャップと特定。実装: globals.css に暖色シャドウトークン（card/button/destructive/floating, light/dark）を定義し Tailwind shadow スケールへマップ。Button(700・角丸14・主役/削除に暖色シャドウ)、Card/Dialog/AlertDialog タイトルを font-bold(700, フォントに600非搭載のため)、Input(角丸16・bg-card・focusボーダー2px)、Dialog/AlertDialog(角丸22)、NurseryCard(角丸18・タイトル700・見学日をピーチ pill チップ化)、NurseryForm セグメント(角丸16・選択時ピーチ塗り+700)、Header(背景 secondary)、EmptyState(ハート+ピーチ円) を反映。検証: lint パス、test 106件全パス（アクセシブル名維持）、build 成功（8ルート）。
+**Context**: 追加要求 - デザイン忠実再現 (Code Generation + Build and Test, COMPLETE)
+
+---
+
+## 完成版B 取り込み・実装（claude_design MCP / DesignSync）
+**Timestamp**: 2026-06-24T01:00:00Z
+**User Input**: "claude_design MCP connector を接続。claude.ai/design プロジェクト f1a5efc7-... を import し、保活手帳 完成版B.dc.html を実装"
+**AI Response**: DesignSync(list_projects) で claude.ai ログインに design 権限を付与（書込可能な Design System プロジェクトは0件）。get_project でプロジェクト「保育園検索メモアプリのデザイン」(type=PROJECT_TYPE_PROJECT, 所有者:千秋) に読み取りアクセス確認。list_files→get_file で「保活手帳 完成版B.dc.html」(65367字, 全6画面×ライト/ダーク)を取得し design_handoff_warm_theme/ にローカル保存（import 完遂）。完成版B と実装を突き合わせ、未反映の「アイコン等」を実装: (1) Header にブランドハートロゴ(2色塗り, components/layout/AppLogo.tsx 新規, ダーク対応), (2) OnboardingDialog のできることをピーチ円+チェックアイコンのリスト+プライバシー注記ボックスへ, (3) VisitTipsDialog をピーチ円の番号バッジへ, (4) NurseryDetail「見学のコツを見る」にノートアイコン追加。コピー文言は維持しテスト不変。検証: lint パス(83ファイル)/test 106件全パス/build 成功(8ルート)。
+**Context**: 追加要求 - 完成版B 取り込み・実装 (Code Generation + Build and Test, COMPLETE)
+
+---
+
+## 修正 - 他ページのヘッダー背景色
+**Timestamp**: 2026-06-24T01:20:00Z
+**User Input**: "トップページ以外のヘッダーの背景色が反映されていなさそう"
+**AI Response**: トップは共有 Header(bg-secondary)だが、追加・詳細・編集ページは各ファイル内インライン <header> が bg-background のままだったと特定。app/add/page.tsx, app/nursery/[id]/page.tsx, app/nursery/[id]/edit/{visit-date,memo,name}/page.tsx の計9箇所を bg-secondary に統一。検証: 残存 bg-background ヘッダー0件、lint パス、build 成功。今後の再発防止に共有 BackHeader コンポーネント化を提案。
+**Context**: 追加要求 - 不具合修正 (COMPLETE)
+
+---
+
+## リファクタ - 共有 BackHeader への集約
+**Timestamp**: 2026-06-24T01:40:00Z
+**User Input**: "リファクタして"
+**AI Response**: 5ページに重複していたインライン <header>（計9箇所）を共有 components/layout/BackHeader.tsx に集約。API: title?/backHref?(SlideLinkで戻る)/onBack?(コールバック)/backAriaLabel?/showBackText?/actions?(右アクション)。背景は bg-secondary に統一済み。add(アイコンのみ戻る+タイトル)、detail(2: タイトル付き backHref)、visit-date(2: onBack)、memo/name(2: onBack + 完了 actions) を置換。各ページの未使用 import（ChevronLeft/ArrowLeft/Link/SlideLink/Button 一部）を整理。アクセシビリティ（aria-label "戻る"）と挙動（slide back / discard 確認）は維持。検証: app 内インライン <header> 0件、lint パス(84ファイル)、test 106件全パス、build 成功。
+**Context**: 追加要求 - リファクタリング (COMPLETE)
+
+---
+
+## コードレビュー対応（/code-review high → 10指摘）
+**Timestamp**: 2026-06-24T02:10:00Z
+**User Input**: "トップ３修正して" → "対応して"
+**AI Response**: 多エージェントレビューで10指摘を抽出・検証。トップ3（input の focus border-2 によるガタつき→リング統一、shadow-lg 一律 floating で toast/Cookie 過剰→--shadow-elevated 新設しダイアログのみ floating 直接指定、Textarea を Input に統一）を修正。続けて残り対応: BackHeader を backHref/onBack 判別ユニオン型化(#4)、角丸を --radius スケール(sm12/md14/lg16/xl18/2xl22)へトークン化し arbitrary px を全廃(#5)、共通 IconCircle 抽出で3箇所のピーチ円を統一(#8)、AppLogo 色を --logo-fill/--logo-stroke トークン化(#9)、Storybook preview に ThemeProvider デコレータ追加(#10)。#6 はシャドウ3層化で解消、#7(空状態ハート)はデザインがストロークのみ＝lucide Heart で既に忠実なため対象外と判断。検証: lint パス(85)、test 106件全パス、build 成功、arbitrary radius 残存0。
+**Context**: 追加要求 - コードレビュー対応 (COMPLETE)
+
+---

--- a/app/add/page.tsx
+++ b/app/add/page.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { ArrowLeft } from "lucide-react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { BackHeader } from "@/components/layout/BackHeader";
 import { NurseryForm } from "@/components/nursery/NurseryForm";
-import { Button } from "@/components/ui/button";
 import { useNurseryStore } from "@/stores/nurseryStore";
 
 export default function AddNurseryPage() {
@@ -18,16 +16,7 @@ export default function AddNurseryPage() {
 
   return (
     <>
-      <header className="sticky top-0 z-10 border-b bg-background">
-        <div className="flex items-center gap-2 px-4 py-3">
-          <Button variant="ghost" size="icon" asChild>
-            <Link href="/" aria-label="戻る">
-              <ArrowLeft className="h-5 w-5" />
-            </Link>
-          </Button>
-          <h1 className="font-bold text-lg">園を追加する</h1>
-        </div>
-      </header>
+      <BackHeader backHref="/" showBackText={false} title="園を追加する" />
 
       <main className="mx-auto max-w-lg px-4 py-6">
         <NurseryForm onAdd={handleAdd} />

--- a/app/globals.css
+++ b/app/globals.css
@@ -20,51 +20,91 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  /* 角丸スケール（--radius=14px を基準に単調増加。案Bの 12/14/16/18/22 に対応） */
+  --radius-sm: calc(var(--radius) - 2px); /* 12px 入力内要素 */
+  --radius-md: var(--radius); /* 14px 既定 */
+  --radius-lg: calc(var(--radius) + 2px); /* 16px 入力/ボタン */
+  --radius-xl: calc(var(--radius) + 4px); /* 18px カード */
+  --radius-2xl: calc(var(--radius) + 8px); /* 22px ダイアログ */
+  --font-sans: var(--font-rounded), "M PLUS Rounded 1c", system-ui, sans-serif;
+  /* 暖色シャドウ: shadcn の shadow ユーティリティを暖色トークンへ差し替え（冷たいグレーの影を使わない） */
+  --shadow-2xs: var(--shadow-card);
+  --shadow-xs: var(--shadow-card);
+  --shadow-sm: var(--shadow-card);
+  --shadow: var(--shadow-card);
+  --shadow-md: var(--shadow-card);
+  --shadow-lg: var(--shadow-elevated);
+  --shadow-xl: var(--shadow-elevated);
+  --shadow-2xl: var(--shadow-elevated);
 }
 
+/* =====================================================================
+   保活手帳 — 案B「あたたかい」テーマ
+   ピーチ＆クリーム × 丸ゴシック / しっかり丸い角
+   ===================================================================== */
+
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  /* 角丸を一段やわらかく（元は 0.625rem） */
+  --radius: 0.875rem;
+
+  --background: oklch(0.972 0.014 64.3);        /* #FDF4EC クリーム地 */
+  --foreground: oklch(0.412 0.034 52.5);        /* #5A463A 文字（ブラウン） */
+  --card: oklch(0.992 0.006 75.4);              /* #FFFCF8 カード */
+  --card-foreground: oklch(0.412 0.034 52.5);   /* #5A463A */
+  --primary: oklch(0.645 0.131 37.8);           /* #D06E50 ピーチ（主役） */
+  --primary-foreground: oklch(1 0 0);           /* #FFFFFF */
+  --secondary: oklch(0.933 0.028 58.8);         /* #F8E5D7 ソフトピーチ面 */
+  --secondary-foreground: oklch(0.412 0.034 52.5); /* #5A463A */
+  --muted: oklch(0.944 0.020 65.1);             /* #F6EADF */
+  --muted-foreground: oklch(0.661 0.046 56.4);  /* #A98C78 補助文字 */
+  --accent: oklch(0.925 0.037 52.7);            /* #FBE0D0 チップ背景 */
+  --accent-foreground: oklch(0.553 0.139 38.5); /* #B4502F */
+  --destructive: oklch(0.577 0.190 25.0);       /* 暖色寄りの赤 */
+  --destructive-foreground: oklch(0.985 0 0);
+  --border: oklch(0.911 0.028 62.3);            /* #F0DECF */
+  --input: oklch(0.899 0.033 60.1);             /* #EFD9C8 */
+  --ring: oklch(0.645 0.131 37.8);              /* #D06E50 */
+
+  /* 暖色シャドウ（茶/ピーチを含ませ、階層を浮きの強さで表す） */
+  --shadow-card: 0 2px 8px rgba(199, 108, 74, 0.07);          /* カード/面 */
+  --shadow-button: 0 6px 14px rgba(208, 110, 80, 0.3);        /* 主役ボタン */
+  --shadow-button-destructive: 0 4px 10px rgba(192, 73, 46, 0.28); /* 削除ボタン */
+  --shadow-elevated: 0 8px 24px rgba(60, 45, 35, 0.12);       /* トースト/Cookie 等の中程度の浮き */
+  --shadow-floating: 0 18px 44px rgba(58, 34, 24, 0.3);       /* ダイアログ（最前面） */
+
+  /* ブランドロゴ（2色塗りのハート）の色。パレットには無い専用シェードのため独立トークン化 */
+  --logo-fill: #f3b996;
+  --logo-stroke: #d06e50;
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.145 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.985 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
-  --border: oklch(0.269 0 0);
-  --input: oklch(0.269 0 0);
-  --ring: oklch(0.439 0 0);
+  --background: oklch(0.225 0.017 58.6);         /* #221A14 あたたかいダーク地 */
+  --foreground: oklch(0.929 0.025 57.7);         /* #F5E4D8 */
+  --card: oklch(0.269 0.025 53.0);               /* #30231B */
+  --card-foreground: oklch(0.929 0.025 57.7);    /* #F5E4D8 */
+  --primary: oklch(0.684 0.126 38.3);            /* #DB7C5E ダークでも映えるピーチ */
+  --primary-foreground: oklch(0.231 0.033 44.7); /* #2A1810 */
+  --secondary: oklch(0.301 0.030 53.3);          /* #3A2A20 */
+  --secondary-foreground: oklch(0.929 0.025 57.7); /* #F5E4D8 */
+  --muted: oklch(0.295 0.022 57.8);              /* #352A22 */
+  --muted-foreground: oklch(0.705 0.044 59.9);   /* #B59A85 */
+  --accent: oklch(0.330 0.048 44.8);             /* #4A2D20 チップ背景 */
+  --accent-foreground: oklch(0.752 0.119 41.4);  /* #EE9472 */
+  --destructive: oklch(0.505 0.165 26.0);
+  --destructive-foreground: oklch(0.929 0.025 57.7);
+  --border: oklch(0.325 0.031 54.2);             /* #413025 */
+  --input: oklch(0.325 0.031 54.2);              /* #413025 */
+  --ring: oklch(0.684 0.126 38.3);               /* #DB7C5E */
+
+  /* 暖色シャドウ（ダーク） */
+  --shadow-card: 0 2px 8px rgba(0, 0, 0, 0.3);
+  --shadow-button: 0 6px 14px rgba(219, 124, 94, 0.3);
+  --shadow-button-destructive: 0 4px 10px rgba(217, 87, 60, 0.3);
+  --shadow-elevated: 0 8px 24px rgba(0, 0, 0, 0.4);
+  --shadow-floating: 0 18px 44px rgba(0, 0, 0, 0.5);
+
+  --logo-fill: #6b3b2a;
+  --logo-stroke: #ee9472;
 }
 
 @layer base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,17 @@
 import type { Metadata, Viewport } from "next";
+import { M_PLUS_Rounded_1c } from "next/font/google";
 import { CookieConsent } from "@/components/common/CookieConsent";
+import { ThemeProvider } from "@/components/common/ThemeProvider";
 import { ViewTransitionResolver } from "@/components/common/ViewTransitionResolver";
 import "./globals.css";
+
+// 丸ゴシック。CSS 変数 --font-rounded として globals.css の --font-sans から参照される
+const rounded = M_PLUS_Rounded_1c({
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+  variable: "--font-rounded",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "保活手帳",
@@ -19,11 +29,18 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ja">
+    <html lang="ja" className={rounded.variable} suppressHydrationWarning>
       <body className="min-h-dvh bg-background font-sans text-foreground antialiased">
-        <ViewTransitionResolver />
-        {children}
-        <CookieConsent />
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <ViewTransitionResolver />
+          {children}
+          <CookieConsent />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -7,8 +7,8 @@ export default function manifest(): MetadataRoute.Manifest {
     description: "保育園見学の記録を残すアプリ",
     start_url: "/",
     display: "standalone",
-    background_color: "#ffffff",
-    theme_color: "#0a0a0a",
+    background_color: "#FDF4EC",
+    theme_color: "#D06E50",
     orientation: "portrait",
     icons: [
       {

--- a/app/nursery/[id]/edit/memo/page.tsx
+++ b/app/nursery/[id]/edit/memo/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { ChevronLeft } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+import { BackHeader } from "@/components/layout/BackHeader";
 import { DiscardChangesDialog } from "@/components/nursery/DiscardChangesDialog";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -73,19 +73,7 @@ export default function EditMemoPage() {
   if (!nursery) {
     return (
       <>
-        <header className="sticky top-0 z-10 border-b bg-background">
-          <div className="flex items-center gap-2 px-4 py-3">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => navigateBack()}
-              className="gap-1 px-2"
-            >
-              <ChevronLeft className="h-5 w-5" />
-              戻る
-            </Button>
-          </div>
-        </header>
+        <BackHeader onBack={() => navigateBack()} />
         <main className="mx-auto max-w-lg px-4 py-6">
           <p className="text-muted-foreground">園が見つかりません。</p>
         </main>
@@ -95,22 +83,14 @@ export default function EditMemoPage() {
 
   return (
     <>
-      <header className="sticky top-0 z-10 border-b bg-background">
-        <div className="flex items-center justify-between px-4 py-3">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleBack}
-            className="gap-1 px-2"
-          >
-            <ChevronLeft className="h-5 w-5" />
-            戻る
-          </Button>
+      <BackHeader
+        onBack={handleBack}
+        actions={
           <Button size="sm" onClick={handleSave} disabled={!hasChanges}>
             完了
           </Button>
-        </div>
-      </header>
+        }
+      />
 
       <main className="mx-auto max-w-lg px-4 py-6">
         <h1 className="mb-6 font-bold text-lg">メモを編集</h1>

--- a/app/nursery/[id]/edit/name/page.tsx
+++ b/app/nursery/[id]/edit/name/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { ChevronLeft } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+import { BackHeader } from "@/components/layout/BackHeader";
 import { DiscardChangesDialog } from "@/components/nursery/DiscardChangesDialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -75,19 +75,7 @@ export default function EditNamePage() {
   if (!nursery) {
     return (
       <>
-        <header className="sticky top-0 z-10 border-b bg-background">
-          <div className="flex items-center gap-2 px-4 py-3">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => navigateBack()}
-              className="gap-1 px-2"
-            >
-              <ChevronLeft className="h-5 w-5" />
-              戻る
-            </Button>
-          </div>
-        </header>
+        <BackHeader onBack={() => navigateBack()} />
         <main className="mx-auto max-w-lg px-4 py-6">
           <p className="text-muted-foreground">園が見つかりません。</p>
         </main>
@@ -97,17 +85,9 @@ export default function EditNamePage() {
 
   return (
     <>
-      <header className="sticky top-0 z-10 border-b bg-background">
-        <div className="flex items-center justify-between px-4 py-3">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleBack}
-            className="gap-1 px-2"
-          >
-            <ChevronLeft className="h-5 w-5" />
-            戻る
-          </Button>
+      <BackHeader
+        onBack={handleBack}
+        actions={
           <Button
             size="sm"
             onClick={handleSave}
@@ -115,8 +95,8 @@ export default function EditNamePage() {
           >
             完了
           </Button>
-        </div>
-      </header>
+        }
+      />
 
       <main className="mx-auto max-w-lg px-4 py-6">
         <h1 className="mb-6 font-bold text-lg">園名を編集</h1>

--- a/app/nursery/[id]/edit/visit-date/page.tsx
+++ b/app/nursery/[id]/edit/visit-date/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { ChevronLeft } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { Button } from "@/components/ui/button";
+import { BackHeader } from "@/components/layout/BackHeader";
 import { CalendarPicker } from "@/components/ui/calendar-picker";
 import { ToastContainer } from "@/components/ui/toast";
 import { useHydrated } from "@/hooks/useHydrated";
@@ -53,19 +52,7 @@ export default function EditVisitDatePage() {
   if (!nursery) {
     return (
       <>
-        <header className="sticky top-0 z-10 border-b bg-background">
-          <div className="flex items-center gap-2 px-4 py-3">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => navigateBack()}
-              className="gap-1 px-2"
-            >
-              <ChevronLeft className="h-5 w-5" />
-              戻る
-            </Button>
-          </div>
-        </header>
+        <BackHeader onBack={() => navigateBack()} />
         <main className="mx-auto max-w-lg px-4 py-6">
           <p className="text-muted-foreground">園が見つかりません。</p>
         </main>
@@ -75,19 +62,7 @@ export default function EditVisitDatePage() {
 
   return (
     <>
-      <header className="sticky top-0 z-10 border-b bg-background">
-        <div className="flex items-center px-4 py-3">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => navigateBack()}
-            className="gap-1 px-2"
-          >
-            <ChevronLeft className="h-5 w-5" />
-            戻る
-          </Button>
-        </div>
-      </header>
+      <BackHeader onBack={() => navigateBack()} />
 
       <main className="mx-auto max-w-lg px-4 py-6">
         <h1 className="mb-6 font-bold text-lg">見学日を選択</h1>

--- a/app/nursery/[id]/page.tsx
+++ b/app/nursery/[id]/page.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { ChevronLeft } from "lucide-react";
-import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
-import { SlideLink } from "@/components/common/SlideLink";
+import { BackHeader } from "@/components/layout/BackHeader";
 import { DeleteNurseryDialog } from "@/components/nursery/DeleteNurseryDialog";
 import { NurseryDetail } from "@/components/nursery/NurseryDetail";
 import { VisitTipsDialog } from "@/components/nursery/VisitTipsDialog";
@@ -41,17 +39,7 @@ export default function NurseryDetailPage() {
   if (!nursery) {
     return (
       <>
-        <header className="sticky top-0 z-10 border-b bg-background">
-          <div className="flex items-center gap-2 px-4 py-3">
-            <Button variant="ghost" size="sm" asChild className="gap-1 px-2">
-              <Link href="/" aria-label="戻る">
-                <ChevronLeft className="h-5 w-5" />
-                戻る
-              </Link>
-            </Button>
-            <h1 className="font-bold text-lg">園が見つかりません</h1>
-          </div>
-        </header>
+        <BackHeader backHref="/" title="園が見つかりません" />
         <main className="mx-auto max-w-lg px-4 py-6">
           <p className="text-muted-foreground">
             この園は削除されたか、存在しません。
@@ -63,17 +51,7 @@ export default function NurseryDetailPage() {
 
   return (
     <>
-      <header className="sticky top-0 z-10 border-b bg-background">
-        <div className="flex items-center gap-2 px-4 py-3">
-          <Button variant="ghost" size="sm" asChild className="gap-1 px-2">
-            <SlideLink href="/" direction="back" aria-label="戻る">
-              <ChevronLeft className="h-5 w-5" />
-              戻る
-            </SlideLink>
-          </Button>
-          <h1 className="font-bold text-lg">園の詳細</h1>
-        </div>
-      </header>
+      <BackHeader backHref="/" title="園の詳細" />
 
       <main className="mx-auto max-w-lg px-4 py-6">
         <NurseryDetail
@@ -83,7 +61,7 @@ export default function NurseryDetailPage() {
 
         <div className="mt-12 border-t pt-6">
           <Button
-            variant="destructive"
+            variant="destructive-outline"
             className="w-full"
             onClick={() => setShowDeleteDialog(true)}
           >

--- a/components/common/ThemeProvider.tsx
+++ b/components/common/ThemeProvider.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ComponentProps } from "react";
+
+// next-themes の薄いラッパー。layout.tsx（Server Component）から
+// "use client" 境界を挟んで利用できるようにする
+export function ThemeProvider({
+  children,
+  ...props
+}: ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/components/layout/AppLogo.tsx
+++ b/components/layout/AppLogo.tsx
@@ -11,7 +11,7 @@ export function AppLogo({ className }: { className?: string }) {
       strokeLinejoin="round"
       aria-hidden="true"
       className={cn(
-        "size-5 fill-[var(--logo-fill)] stroke-[var(--logo-stroke)]",
+        "size-5 fill-(--logo-fill) stroke-(--logo-stroke)",
         className,
       )}
     >

--- a/components/layout/AppLogo.tsx
+++ b/components/layout/AppLogo.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib/utils";
+
+// 案B「あたたかい」のブランドロゴ。2色塗りのハート（塗り＝やわらかいピーチ、線＝主役ピーチ）。
+// 色は globals.css の --logo-fill / --logo-stroke トークンで管理（ライト/ダークで自動切替）。
+export function AppLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      strokeWidth={1.6}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={cn(
+        "size-5 fill-[var(--logo-fill)] stroke-[var(--logo-stroke)]",
+        className,
+      )}
+    >
+      <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" />
+    </svg>
+  );
+}

--- a/components/layout/BackHeader.tsx
+++ b/components/layout/BackHeader.tsx
@@ -1,0 +1,81 @@
+import { ChevronLeft } from "lucide-react";
+import type { ReactNode } from "react";
+import { SlideLink } from "@/components/common/SlideLink";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/** 戻る操作は backHref か onBack のどちらか一方を必須とする（両方／どちらも無し、を型で禁止） */
+type BackNavigation =
+  | { backHref: string; onBack?: never }
+  | { onBack: () => void; backHref?: never };
+
+type BackHeaderProps = BackNavigation & {
+  /** 見出し（省略可） */
+  title?: string;
+  /** 戻るボタンのアクセシブル名（既定: "戻る"） */
+  backAriaLabel?: string;
+  /** 「戻る」テキストを表示するか（false でアイコンのみ／既定: true） */
+  showBackText?: boolean;
+  /** 右側のアクション（完了ボタン等） */
+  actions?: ReactNode;
+};
+
+/**
+ * 各ページ共通の戻るヘッダー。ピーチ面（secondary）背景に統一する。
+ * 戻る操作は backHref（SlideLink で戻る遷移）か onBack（コールバック）のどちらかで指定する。
+ */
+export function BackHeader({
+  title,
+  backHref,
+  onBack,
+  backAriaLabel = "戻る",
+  showBackText = true,
+  actions,
+}: BackHeaderProps) {
+  const backInner = (
+    <>
+      <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+      {showBackText && backAriaLabel}
+    </>
+  );
+
+  // 戻るボタンの共通 props。テキストを出すときは可視ラベルがアクセシブル名になるため
+  // aria-label は不要、アイコンのみのときだけ付与する。
+  const backButtonProps = {
+    variant: "ghost",
+    size: "sm",
+    className: "gap-1 px-2",
+    "aria-label": showBackText ? undefined : backAriaLabel,
+  } as const;
+
+  return (
+    <header className="sticky top-0 z-10 border-b bg-secondary">
+      <div
+        className={cn(
+          "flex items-center gap-2 px-4 py-3",
+          actions && "justify-between",
+        )}
+      >
+        <div className="flex items-center gap-2">
+          {backHref ? (
+            <Button {...backButtonProps} asChild>
+              <SlideLink href={backHref} direction="back">
+                {backInner}
+              </SlideLink>
+            </Button>
+          ) : (
+            <Button {...backButtonProps} onClick={onBack}>
+              {backInner}
+            </Button>
+          )}
+          {title && (
+            <h1 className="font-bold text-lg text-secondary-foreground">
+              {title}
+            </h1>
+          )}
+        </div>
+        {actions}
+      </div>
+    </header>
+  );
+}

--- a/components/layout/EmptyState.tsx
+++ b/components/layout/EmptyState.tsx
@@ -1,5 +1,6 @@
-import { Plus } from "lucide-react";
+import { Heart, Plus } from "lucide-react";
 import Link from "next/link";
+import { IconCircle } from "@/components/layout/IconCircle";
 import { Button } from "@/components/ui/button";
 
 interface EmptyStateProps {
@@ -15,12 +16,15 @@ export function EmptyState({
 }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
-      <p className="font-medium text-lg text-muted-foreground">{message}</p>
+      <IconCircle className="mb-4 size-14 bg-secondary">
+        <Heart className="size-7 text-primary" aria-hidden="true" />
+      </IconCircle>
+      <p className="font-bold text-lg text-muted-foreground">{message}</p>
       {description && (
         <p className="mt-2 text-muted-foreground text-sm">{description}</p>
       )}
       {showAddButton && (
-        <Button asChild size="sm" className="mt-4">
+        <Button asChild className="mt-4">
           <Link href="/add">
             <Plus className="mr-1 h-4 w-4" />
             園を追加する

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { CircleHelp } from "lucide-react";
+import { AppLogo } from "@/components/layout/AppLogo";
+import { ThemeToggle } from "@/components/layout/ThemeToggle";
 import { Button } from "@/components/ui/button";
 
 interface HeaderProps {
@@ -9,17 +11,25 @@ interface HeaderProps {
 
 export function Header({ onHelpClick }: HeaderProps) {
   return (
-    <header className="sticky top-0 z-10 border-b bg-background">
+    <header className="sticky top-0 z-10 border-b bg-secondary">
       <div className="flex items-center justify-between px-4 py-3">
-        <h1 className="font-bold text-lg">保活手帳</h1>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onHelpClick}
-          aria-label="ヘルプ"
-        >
-          <CircleHelp className="h-5 w-5" />
-        </Button>
+        <div className="flex items-center gap-2">
+          <AppLogo />
+          <h1 className="font-bold text-lg text-secondary-foreground">
+            保活手帳
+          </h1>
+        </div>
+        <div className="flex items-center gap-1">
+          <ThemeToggle />
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onHelpClick}
+            aria-label="ヘルプ"
+          >
+            <CircleHelp className="h-5 w-5" />
+          </Button>
+        </div>
       </div>
     </header>
   );

--- a/components/layout/IconCircle.tsx
+++ b/components/layout/IconCircle.tsx
@@ -1,0 +1,23 @@
+import type { ComponentProps } from "react";
+import { cn } from "@/lib/utils";
+
+// アイコンや短いラベルを丸い面に収める共通バッジ。
+// 既定はピーチ面（bg-accent）。size/bg/文字色は className で上書きする。
+// オンボーディングのチェック、見学のコツの番号、空状態のハート等で再利用する。
+export function IconCircle({
+  className,
+  children,
+  ...props
+}: ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "flex shrink-0 items-center justify-center rounded-full bg-accent",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/components/layout/ThemeToggle.tsx
+++ b/components/layout/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+// ライト⇄ダークを手動で切り替えるトグル。OS設定（system）にも追従する
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  // サーバー描画時はテーマが未確定のため、マウント後にのみ実アイコンを表示し
+  // ハイドレーション不一致を避ける
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const isDark = mounted && resolvedTheme === "dark";
+
+  return (
+    <Button
+      size="icon"
+      variant="ghost"
+      disabled={!mounted}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label={isDark ? "ライトモードに切り替え" : "ダークモードに切り替え"}
+    >
+      {isDark ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
+    </Button>
+  );
+}

--- a/components/nursery/DeleteNurseryDialog.tsx
+++ b/components/nursery/DeleteNurseryDialog.tsx
@@ -33,7 +33,7 @@ export function DeleteNurseryDialog({
             「{nurseryName}」を削除します。この操作は取り消せません。
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <AlertDialogFooter>
+        <AlertDialogFooter className="grid grid-cols-2">
           <AlertDialogCancel>キャンセル</AlertDialogCancel>
           <AlertDialogAction onClick={onConfirm} variant="destructive">
             削除

--- a/components/nursery/NurseryCard.tsx
+++ b/components/nursery/NurseryCard.tsx
@@ -1,5 +1,7 @@
+import { Calendar } from "lucide-react";
 import { SlideLink } from "@/components/common/SlideLink";
 import { formatVisitDate } from "@/lib/formatDate";
+import { cn } from "@/lib/utils";
 import type { Nursery } from "@/types/nursery";
 
 interface NurseryCardProps {
@@ -8,16 +10,25 @@ interface NurseryCardProps {
 
 export function NurseryCard({ nursery }: NurseryCardProps) {
   const formattedDate = formatVisitDate(nursery.visitDate);
+  const hasDate = Boolean(nursery.visitDate);
 
   return (
     <SlideLink
       href={`/nursery/${nursery.id}`}
       direction="forward"
-      className="block rounded-lg border bg-card p-4 shadow-sm transition-colors hover:bg-accent/50"
+      className="block rounded-xl border bg-card p-4 shadow-sm transition-colors hover:bg-accent/50"
     >
       <div className="flex items-start justify-between gap-2">
-        <h2 className="font-medium text-base">{nursery.name}</h2>
-        <span className="shrink-0 text-muted-foreground text-sm">
+        <h2 className="font-bold text-base">{nursery.name}</h2>
+        <span
+          className={cn(
+            "inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 font-medium text-xs",
+            hasDate
+              ? "bg-accent text-primary"
+              : "bg-muted text-muted-foreground",
+          )}
+        >
+          {hasDate && <Calendar className="size-3" aria-hidden="true" />}
           {formattedDate}
         </span>
       </div>

--- a/components/nursery/NurseryDetail.tsx
+++ b/components/nursery/NurseryDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronRight } from "lucide-react";
+import { BookOpenText, ChevronRight } from "lucide-react";
 import { SlideLink } from "@/components/common/SlideLink";
 import { Button } from "@/components/ui/button";
 import { formatVisitDate } from "@/lib/formatDate";
@@ -84,7 +84,12 @@ export function NurseryDetail({
       </div>
 
       <div>
-        <Button variant="link" onClick={onVisitTipsClick} className="px-0">
+        <Button
+          variant="link"
+          onClick={onVisitTipsClick}
+          className="px-0 font-bold no-underline hover:no-underline"
+        >
+          <BookOpenText className="size-4" aria-hidden="true" />
           見学のコツを見る
         </Button>
       </div>

--- a/components/nursery/NurseryForm.tsx
+++ b/components/nursery/NurseryForm.tsx
@@ -49,10 +49,10 @@ export function NurseryForm({ onAdd }: NurseryFormProps) {
             onClick={() => setVisitDateOption("today")}
             aria-pressed={visitDateOption === "today"}
             className={cn(
-              "rounded-xl border-2 px-4 py-3 text-center text-sm font-medium transition-colors",
+              "rounded-lg border-2 px-4 py-3 text-center text-sm transition-colors",
               visitDateOption === "today"
-                ? "border-primary bg-primary/5 text-primary"
-                : "border-border text-muted-foreground hover:border-primary/50",
+                ? "border-primary bg-accent font-bold text-primary"
+                : "border-border bg-card font-medium text-muted-foreground hover:border-primary/50",
             )}
           >
             今日
@@ -62,10 +62,10 @@ export function NurseryForm({ onAdd }: NurseryFormProps) {
             onClick={() => setVisitDateOption("later")}
             aria-pressed={visitDateOption === "later"}
             className={cn(
-              "rounded-xl border-2 px-4 py-3 text-center text-sm font-medium transition-colors",
+              "rounded-lg border-2 px-4 py-3 text-center text-sm transition-colors",
               visitDateOption === "later"
-                ? "border-primary bg-primary/5 text-primary"
-                : "border-border text-muted-foreground hover:border-primary/50",
+                ? "border-primary bg-accent font-bold text-primary"
+                : "border-border bg-card font-medium text-muted-foreground hover:border-primary/50",
             )}
           >
             あとで設定する
@@ -73,7 +73,7 @@ export function NurseryForm({ onAdd }: NurseryFormProps) {
         </div>
       </div>
 
-      <Button type="submit" className="w-full" disabled={!isValid}>
+      <Button type="submit" size="lg" className="w-full" disabled={!isValid}>
         追加する
       </Button>
     </form>

--- a/components/nursery/VisitTipsDialog.tsx
+++ b/components/nursery/VisitTipsDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { IconCircle } from "@/components/layout/IconCircle";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -44,13 +45,21 @@ export function VisitTipsDialog({ open, onClose }: VisitTipsDialogProps) {
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-2">
+        <div className="space-y-3.5 py-2">
           {VISIT_TIPS.map((tip, index) => (
-            <div key={tip.title} className="space-y-1">
-              <h3 className="font-medium text-sm">
-                {index + 1}. {tip.title}
-              </h3>
-              <p className="text-muted-foreground text-sm">{tip.description}</p>
+            <div key={tip.title} className="flex gap-3">
+              <IconCircle
+                className="size-6 font-bold text-primary text-xs"
+                aria-hidden="true"
+              >
+                {index + 1}
+              </IconCircle>
+              <div className="space-y-1">
+                <h3 className="font-bold text-sm">{tip.title}</h3>
+                <p className="text-muted-foreground text-sm leading-relaxed">
+                  {tip.description}
+                </p>
+              </div>
             </div>
           ))}
         </div>

--- a/components/onboarding/OnboardingDialog.tsx
+++ b/components/onboarding/OnboardingDialog.tsx
@@ -29,7 +29,13 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent
         showCloseButton={false}
-        onOpenAutoFocus={(e) => e.preventDefault()}
+        onOpenAutoFocus={(event) => {
+          // 「はじめる」ボタンへの自動フォーカス（初回表示時のリング）は避けつつ、
+          // a11y のためフォーカスはダイアログ本体へ移す（SR がタイトルを読み上げ、
+          // フォーカストラップも維持される）。
+          event.preventDefault();
+          (event.currentTarget as HTMLElement | null)?.focus();
+        }}
       >
         <DialogHeader>
           <DialogTitle>保活手帳へようこそ</DialogTitle>

--- a/components/onboarding/OnboardingDialog.tsx
+++ b/components/onboarding/OnboardingDialog.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Check } from "lucide-react";
+import { IconCircle } from "@/components/layout/IconCircle";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -15,10 +17,20 @@ interface OnboardingDialogProps {
   onClose: () => void;
 }
 
+const FEATURES = [
+  "見学候補の園をリストアップ",
+  "見学日を記録",
+  "見学で気づいたことをメモ",
+  "あとから一覧で見返す",
+];
+
 export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent showCloseButton={false}>
+      <DialogContent
+        showCloseButton={false}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>保活手帳へようこそ</DialogTitle>
           <DialogDescription>
@@ -27,26 +39,33 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
         </DialogHeader>
 
         <div className="space-y-4 py-2">
-          <div className="space-y-2">
-            <h3 className="font-medium text-sm">できること</h3>
-            <ul className="list-disc space-y-1 pl-5 text-muted-foreground text-sm">
-              <li>見学候補の園をリストアップ</li>
-              <li>見学日を記録</li>
-              <li>見学で気づいたことをメモ</li>
-              <li>あとから一覧で見返す</li>
+          <div className="space-y-2.5">
+            <h3 className="font-bold text-sm">できること</h3>
+            <ul className="space-y-2">
+              {FEATURES.map((feature) => (
+                <li
+                  key={feature}
+                  className="flex items-center gap-2.5 text-foreground text-sm"
+                >
+                  <IconCircle className="size-5">
+                    <Check
+                      className="size-3 stroke-3 text-primary"
+                      aria-hidden="true"
+                    />
+                  </IconCircle>
+                  {feature}
+                </li>
+              ))}
             </ul>
           </div>
 
-          <div className="space-y-2">
-            <h3 className="font-medium text-sm">データの保存について</h3>
-            <p className="text-muted-foreground text-sm">
-              すべてのデータはお使いの端末（ブラウザ）に保存されます。サーバーへの送信は行いません。
-            </p>
-          </div>
+          <p className="rounded-md bg-muted px-3.5 py-3 text-muted-foreground text-sm leading-relaxed">
+            すべてのデータはお使いの端末（ブラウザ）に保存されます。サーバーへの送信は行いません。
+          </p>
         </div>
 
         <DialogFooter>
-          <Button onClick={onClose} className="w-full">
+          <Button onClick={onClose} size="lg" className="w-full">
             はじめる
           </Button>
         </DialogFooter>

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -55,7 +55,7 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          "group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
+          "group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border bg-card p-6 shadow-[var(--shadow-floating)] duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
           className,
         )}
         {...props}
@@ -104,7 +104,7 @@ function AlertDialogTitle({
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
       className={cn(
-        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        "font-bold text-lg sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
         className,
       )}
       {...props}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,13 +5,16 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-lg text-sm font-bold whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-primary text-primary-foreground shadow-[var(--shadow-button)] hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+          "bg-destructive text-white shadow-[var(--shadow-button-destructive)] hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+        "destructive-outline":
+          "border border-destructive/40 bg-transparent text-destructive hover:bg-destructive/10 focus-visible:ring-destructive/20 dark:border-destructive/50 dark:focus-visible:ring-destructive/40",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
@@ -21,10 +24,10 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        default: "h-10 px-5 py-2 has-[>svg]:px-4",
         xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        sm: "h-8 gap-1.5 rounded-md px-3.5 has-[>svg]:px-3",
+        lg: "h-12 px-6 text-base has-[>svg]:px-5",
         icon: "size-9",
         "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
         "icon-sm": "size-8",

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -32,7 +32,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn("font-bold leading-none", className)}
       {...props}
     />
   );

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -58,7 +58,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border bg-card p-6 shadow-[var(--shadow-floating)] duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
           className,
         )}
         {...props}
@@ -122,7 +122,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn("font-bold text-lg leading-none", className)}
       {...props}
     />
   );

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+        "h-9 w-full min-w-0 rounded-lg border border-input bg-card px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
         "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
         className,

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-card px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:aria-invalid:ring-destructive/40",
         className,
       )}
       {...props}

--- a/css.d.ts
+++ b/css.d.ts
@@ -1,0 +1,3 @@
+// グローバル CSS の副作用インポート（例: import "./globals.css"）に型を与える。
+// Next.js の型は CSS Modules 用のみで、プレーン CSS の宣言が無いため補う。
+declare module "*.css";

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^1.18.0",
     "next": "^16.2.9",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.5.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       next:
         specifier: ^16.2.9
         version: 16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       radix-ui:
         specifier: ^1.5.0
         version: 1.5.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2728,6 +2731,12 @@ packages:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@16.2.9:
     resolution: {integrity: sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==}
@@ -5618,6 +5627,11 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
+
+  next-themes@0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:


### PR DESCRIPTION
## 概要
案B「あたたかい」テーマ（ピーチ＆クリーム × 丸ゴシック）を既存アプリに適用し、next-themes によるダークモードを実装しました。機能・画面構成は変更せず、ビジュアル（カラートークン・フォント・角丸・影）とダークモード切替を中心とした変更です。

## 主な変更
- **テーマトークン**: カラー（oklch・ライト/ダーク）、丸ゴシック（M PLUS Rounded 1c）、角丸スケール（sm/md/lg/xl/2xl）、暖色シャドウ（card / elevated / floating）を `app/globals.css` に定義
- **ダークモード**: `next-themes` を導入（`ThemeProvider` / `ThemeToggle`、Header にトグル追加、OS 設定に追従）
- **デザイン忠実化（design-system / 完成版B 準拠）**: ブランドハートロゴ（`AppLogo`）、見学日チップ、オンボーディング/見学のコツのバッジ（`IconCircle`）、空状態、削除ボタンのアウトライン化
- **調整**: ボタンの余白・ダイアログのボタン配置をデザインに合わせて調整
- **リファクタ**: 重複していたページヘッダーを共有 `BackHeader` に集約
- **UX**: オンボーディング初回表示時のオートフォーカス（リング表示）を抑止
- **型**: CSS 副作用インポート用に `css.d.ts` を追加（TypeScript 6 の `noUncheckedSideEffectImports` 既定オン対応）

## 動作確認
- `pnpm lint` — 指摘なし
- `pnpm test` — 106 件 全パス
- `pnpm build` — 成功

## スクリーンショット
（ライト/ダークの 一覧・追加・詳細・ダイアログ・空状態 を添付してください）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * テーマ切り替え（ライト/ダーク、システム連動）とヘッダーのロゴ・切り替えボタンを追加。
  * 共通「戻る」ヘッダーを導入し、各編集画面の導線を統一。
* **改善**
  * あたたかい配色と影・角丸・フォントを全体に適用し、ダイアログやボタン等の見た目も調整。
* **バグ修正**
  * Storybook上でもテーマが正しく反映されるよう修正。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->